### PR TITLE
Add egress destinations to API and Dockerfile

### DIFF
--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -1,3 +1,5 @@
+use crate::config::EgressSettings;
+
 use super::client::{ApiClient, ApiClientError, ApiResult, GenericApiClient, HandleResponse};
 use super::AuthMode;
 use reqwest::Client;
@@ -186,6 +188,8 @@ pub struct CreateCageDeploymentIntentRequest {
     pcrs: crate::enclave::PCRs,
     debug_mode: bool,
     egress_enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    egress_domains: Option<Vec<String>>,
     eif_size_bytes: u64,
 }
 
@@ -193,14 +197,15 @@ impl CreateCageDeploymentIntentRequest {
     pub fn new(
         pcrs: &crate::enclave::PCRs,
         debug_mode: bool,
-        egress_enabled: bool,
+        egress_settings: EgressSettings,
         eif_size_bytes: u64,
     ) -> Self {
         Self {
             pcrs: pcrs.clone(),
             debug_mode,
-            egress_enabled,
+            egress_enabled: egress_settings.enabled,
             eif_size_bytes,
+            egress_domains: egress_settings.destinations,
         }
     }
 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -208,8 +208,10 @@ async fn process_dockerfile<R: AsyncRead + std::marker::Unpin>(
 
     let egress = build_config.clone().egress;
     if egress.is_enabled() {
-        let ports = Directive::new_env("EGRESS_PORTS", &egress.get_ports());
-        env_directives.push(ports)
+        let ports = Directive::new_env("EGRESS_PORTS", &egress.clone().get_ports());
+        env_directives.push(ports);
+        let domains = Directive::new_env("EV_EGRESS_ALLOW_LIST", &egress.get_destinations());
+        env_directives.push(domains)
     };
 
     let injected_directives = vec![

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -1,4 +1,4 @@
-use chrono::Datelike;
+use chrono::{Datelike, Utc};
 use itertools::Itertools;
 use rcgen::CertificateParams;
 use std::io::Write;
@@ -17,7 +17,7 @@ pub fn create_new_cert(
 
     add_distinguished_name_to_cert_params(&mut cert_params, distinguished_name);
 
-    let today = chrono::Utc::today();
+    let today = Utc::now();
     cert_params.not_before =
         rcgen::date_time_ymd(today.year(), today.month() as u8, today.day() as u8);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,29 @@ pub struct EgressSettings {
 }
 
 impl EgressSettings {
+    pub fn new(
+        ports: Option<Vec<String>>,
+        destinations: Option<Vec<String>>,
+        enabled: bool,
+    ) -> EgressSettings {
+        let enabled = enabled || destinations.is_some() || ports.is_some();
+        let destinations = if enabled && destinations.is_none() {
+            Some(vec!["*".to_string()])
+        } else {
+            destinations.clone()
+        };
+        let ports = if enabled && ports.is_none() {
+            Some(vec!["443".to_string()])
+        } else {
+            ports.clone()
+        };
+        EgressSettings {
+            enabled,
+            destinations,
+            ports,
+        }
+    }
+
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }
@@ -18,6 +41,11 @@ impl EgressSettings {
         self.ports
             .map(|ports| ports.join(","))
             .unwrap_or("443".to_string())
+    }
+    pub fn get_destinations(self) -> String {
+        self.destinations
+            .map(|destination| destination.join(","))
+            .unwrap_or("*".to_string())
     }
 }
 

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -39,7 +39,7 @@ pub async fn deploy_eif(
     let cage_deployment_intent_payload = CreateCageDeploymentIntentRequest::new(
         eif_measurements.pcrs(),
         validated_config.debug,
-        validated_config.egress().is_enabled(),
+        validated_config.egress().clone(),
         eif_size_bytes,
     );
     let deployment_intent = cage_api


### PR DESCRIPTION
# Why
We need to lockdown egress destinations to a defined list

# How
Add env var to Dockerfile for use in the data plane
Send the destinations to the API so they can also be enforced in the control plane
