### PR TITLE
[SPE-588] Add command to lock certs to a cage

### DIFF
--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -773,4 +773,40 @@ mod test {
             .is_none());
         assert!(deployment_with_empty_regional.is_failed().is_none());
     }
+
+    #[test]
+    fn test_populated_regional_deployments() {
+        let deployment = get_testing_deployment();
+        let version = get_testing_version();
+        let cert = get_testing_cert();
+
+        let failure_reason = "An error occurred provisioning your TEE".to_string();
+        let detailed_failure_reason = "Insufficient capacity".to_string();
+        let deployment_with_regional = GetCageDeploymentResponse {
+            deployment,
+            tee_cage_version: version,
+            tee_cage_signing_cert: cert,
+            tee_cage_regional_deployments: vec![CageRegionalDeployment {
+                uuid: "abc".to_string(),
+                deployment_uuid: "def".to_string(),
+                deployment_order: 1,
+                region: "us-east-1".to_string(),
+                failure_reason: Some(failure_reason.clone()),
+                deploy_status: DeployStatus::Failed,
+                started_at: None,
+                completed_at: None,
+                detailed_status: Some(detailed_failure_reason.clone()),
+            }],
+        };
+
+        assert_eq!(deployment_with_regional.is_failed(), Some(true));
+        assert_eq!(
+            deployment_with_regional.get_failure_reason(),
+            Some(failure_reason)
+        );
+        assert_eq!(
+            deployment_with_regional.get_detailed_status(),
+            Some(detailed_failure_reason)
+        );
+    }
 }

--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -157,6 +157,32 @@ impl CagesClient {
             .await
     }
 
+    pub async fn update_cage_locked_signing_certs(
+        &self,
+        cage_uuid: &str,
+        payload: UpdateLockedCageSigningCertRequest,
+    ) -> ApiResult<Vec<CageToSigningCert>> {
+        let get_cage_lock_certs_url = format!("{}/{}/signing/certs", self.base_url(), cage_uuid);
+        self.put(&get_cage_lock_certs_url)
+            .json(&payload)
+            .send()
+            .await
+            .handle_json_response()
+            .await
+    }
+
+    pub async fn get_cage_locked_signing_certs(
+        &self,
+        cage_uuid: &str,
+    ) -> ApiResult<Vec<CageSigningCert>> {
+        let get_cage_lock_certs_url = format!("{}/{}/signing/certs", self.base_url(), cage_uuid);
+        self.get(&get_cage_lock_certs_url)
+            .send()
+            .await
+            .handle_json_response()
+            .await
+    }
+
     pub async fn get_cage_cert_by_uuid(&self, cert_uuid: &str) -> ApiResult<CageSigningCert> {
         let get_cert_url = format!("{}/signing/certs/{}", self.base_url(), cert_uuid);
         self.get(&get_cert_url)
@@ -246,6 +272,18 @@ impl CreateCageSigningCertRefRequest {
             not_before,
             not_after,
         }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateLockedCageSigningCertRequest {
+    cert_uuids: Vec<String>,
+}
+
+impl UpdateLockedCageSigningCertRequest {
+    pub fn new(cert_uuids: Vec<String>) -> Self {
+        Self { cert_uuids }
     }
 }
 
@@ -349,6 +387,13 @@ impl CreateCageSigningCertRefResponse {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CageToSigningCert {
+    pub cage_uuid: String,
+    pub signing_cert_uuid: String,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum CageState {
@@ -429,14 +474,59 @@ pub struct CageVersion {
     started_at: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd)]
 #[serde(rename_all = "camelCase")]
 pub struct CageSigningCert {
+    name: Option<String>,
     uuid: String,
     app_uuid: String,
     cert_hash: String,
     not_before: Option<String>,
     not_after: Option<String>,
+}
+
+impl CageSigningCert {
+    pub fn new(
+        name: Option<String>,
+        uuid: String,
+        app_uuid: String,
+        cert_hash: String,
+        not_before: Option<String>,
+        not_after: Option<String>,
+    ) -> Self {
+        Self {
+            name,
+            uuid,
+            app_uuid,
+            cert_hash,
+            not_before,
+            not_after,
+        }
+    }
+
+    pub fn uuid(&self) -> &str {
+        &self.uuid
+    }
+
+    pub fn app_uuid(&self) -> &str {
+        &self.app_uuid
+    }
+
+    pub fn cert_hash(&self) -> &str {
+        &self.cert_hash
+    }
+
+    pub fn not_before(&self) -> Option<String> {
+        self.not_before.clone()
+    }
+
+    pub fn not_after(&self) -> Option<String> {
+        self.not_after.clone()
+    }
+
+    pub fn name(&self) -> Option<String> {
+        self.name.clone()
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -572,7 +662,7 @@ impl GetCageDeploymentResponse {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSigningCertsResponse {
-    certs: Vec<CageSigningCert>,
+    pub certs: Vec<CageSigningCert>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -654,6 +744,7 @@ mod test {
 
     fn get_testing_cert() -> CageSigningCert {
         CageSigningCert {
+            name: Some("abc".to_string()),
             uuid: "abc".to_string(),
             app_uuid: "def".to_string(),
             cert_hash: "ghi".to_string(),
@@ -681,41 +772,5 @@ mod test {
             .get_failure_reason()
             .is_none());
         assert!(deployment_with_empty_regional.is_failed().is_none());
-    }
-
-    #[test]
-    fn test_populated_regional_deployments() {
-        let deployment = get_testing_deployment();
-        let version = get_testing_version();
-        let cert = get_testing_cert();
-
-        let failure_reason = "An error occurred provisioning your TEE".to_string();
-        let detailed_failure_reason = "Insufficient capacity".to_string();
-        let deployment_with_regional = GetCageDeploymentResponse {
-            deployment,
-            tee_cage_version: version,
-            tee_cage_signing_cert: cert,
-            tee_cage_regional_deployments: vec![CageRegionalDeployment {
-                uuid: "abc".to_string(),
-                deployment_uuid: "def".to_string(),
-                deployment_order: 1,
-                region: "us-east-1".to_string(),
-                failure_reason: Some(failure_reason.clone()),
-                deploy_status: DeployStatus::Failed,
-                started_at: None,
-                completed_at: None,
-                detailed_status: Some(detailed_failure_reason.clone()),
-            }],
-        };
-
-        assert_eq!(deployment_with_regional.is_failed(), Some(true));
-        assert_eq!(
-            deployment_with_regional.get_failure_reason(),
-            Some(failure_reason)
-        );
-        assert_eq!(
-            deployment_with_regional.get_detailed_status(),
-            Some(detailed_failure_reason)
-        );
     }
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -60,7 +60,7 @@ pub trait ApiClient {
 
     fn base_url(&self) -> String {
         let domain = std::env::var("EV_DOMAIN").unwrap_or_else(|_| String::from("evervault.com"));
-        format!("http://api.{}", domain)
+        format!("https://api.{}", domain)
     }
 
     fn keys_url(&self) -> String {

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -60,7 +60,7 @@ pub trait ApiClient {
 
     fn base_url(&self) -> String {
         let domain = std::env::var("EV_DOMAIN").unwrap_or_else(|_| String::from("evervault.com"));
-        format!("https://api.{}", domain)
+        format!("http://api.{}", domain)
     }
 
     fn keys_url(&self) -> String {

--- a/src/cert/error.rs
+++ b/src/cert/error.rs
@@ -27,6 +27,8 @@ pub enum CertError {
     ApiError(#[from] crate::api::client::ApiError),
     #[error("An error occurred calculating the hash of the cert — {0}")]
     HashError(String),
+    #[error("Failed to parse timestamp")]
+    TimstampParseError(#[from] chrono::ParseError),
 }
 
 impl CliError for CertError {
@@ -41,7 +43,8 @@ impl CliError for CertError {
             | Self::CertHasExpired
             | Self::CertNotYetValid
             | Self::InvalidDate
-            | Self::CertPathDoesNotExist(_) => exitcode::DATAERR,
+            | Self::CertPathDoesNotExist(_)
+            | Self::TimstampParseError(_) => exitcode::DATAERR,
             Self::ApiError(inner) => inner.exitcode(),
         }
     }

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -12,8 +12,8 @@ use x509_parser::parse_x509_certificate;
 use x509_parser::prelude::{parse_x509_pem, X509Certificate};
 
 use crate::api::cage::{
-    CageSigningCert, CreateCageSigningCertRefRequest,
-    CreateCageSigningCertRefResponse, UpdateLockedCageSigningCertRequest,
+    CageSigningCert, CreateCageSigningCertRefRequest, CreateCageSigningCertRefResponse,
+    UpdateLockedCageSigningCertRequest,
 };
 use crate::api::{self, AuthMode};
 

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -281,6 +281,17 @@ pub async fn lock_cage_to_certs(
         return Err(CertError::ApiError(e));
     };
 
+    let final_msg = match amount_chosen {
+        0 => format!("Cage {} successfully unlocked from all certs!", cage_name),
+        1 => format!("Cage {} successfully locked to 1 cert!", cage_name),
+        _ => format!(
+            "Cage {} successfully locked to {} certs!",
+            cage_name, amount_chosen
+        ),
+    };
+
+    log::info!("{}", final_msg);
+
     Ok(())
 }
 

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -12,7 +12,7 @@ use x509_parser::parse_x509_certificate;
 use x509_parser::prelude::{parse_x509_pem, X509Certificate};
 
 use crate::api::cage::{
-    CageSigningCert, CageToSigningCert, CreateCageSigningCertRefRequest,
+    CageSigningCert, CreateCageSigningCertRefRequest,
     CreateCageSigningCertRefResponse, UpdateLockedCageSigningCertRequest,
 };
 use crate::api::{self, AuthMode};

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -249,9 +249,18 @@ pub async fn lock_cage_to_certs(api_key: &str, cage_uuid: &str) -> Result<(), Ce
 
     let amount_chosen = chosen_cert_uuids.len();
     let msg = match amount_chosen {
-        0 => format!("No certs selected. Cage {} will not be locked to any certs.", cage_uuid),
-        1 => format!("1 cert selected. Cage {} will be locked to this cert.", cage_uuid),
-        _ => format!("{} certs selected. Cage {} will be locked to these certs", amount_chosen, cage_uuid),
+        0 => format!(
+            "No certs selected. Cage {} will not be locked to any certs.",
+            cage_uuid
+        ),
+        1 => format!(
+            "1 cert selected. Cage {} will be locked to this cert.",
+            cage_uuid
+        ),
+        _ => format!(
+            "{} certs selected. Cage {} will be locked to these certs",
+            amount_chosen, cage_uuid
+        ),
     };
 
     log::info!("{}", msg);

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -119,7 +119,7 @@ fn format_cert_for_multi_select(cert: &CageSigningCert) -> String {
     let not_after = cert
         .not_after()
         .and_then(|time| format_expiry_time(&time).ok())
-        .unwrap_or_else(|| "".to_string());
+        .unwrap_or_else(|| "Failed to get cert expiry".to_string());
 
     format!("{} {} ({})", name, cert_hash, not_after)
 }

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -1,5 +1,7 @@
 use aws_nitro_enclaves_image_format::defs::eif_hasher::EifHasher;
-use chrono::{Datelike, TimeZone, Utc};
+use chrono::{DateTime, Datelike, Local, TimeZone, Utc};
+use dialoguer::theme::{ColorfulTheme, SimpleTheme};
+use dialoguer::MultiSelect;
 use itertools::Itertools;
 use rcgen::CertificateParams;
 use sha2::{Digest, Sha384};
@@ -9,7 +11,10 @@ use std::path::{Path, PathBuf};
 use x509_parser::parse_x509_certificate;
 use x509_parser::prelude::{parse_x509_pem, X509Certificate};
 
-use crate::api::cage::{CreateCageSigningCertRefRequest, CreateCageSigningCertRefResponse};
+use crate::api::cage::{
+    CageSigningCert, CageToSigningCert, CreateCageSigningCertRefRequest,
+    CreateCageSigningCertRefResponse, UpdateLockedCageSigningCertRequest,
+};
 use crate::api::{self, AuthMode};
 
 pub mod error;
@@ -107,6 +112,146 @@ pub async fn upload_new_cert_ref(
     };
 
     Ok(cert_ref)
+}
+
+fn format_cert_for_multi_select(cert: &CageSigningCert) -> String {
+    format!(
+        "{} {} ({})",
+        cert.name().unwrap_or("".to_string()),
+        cert.cert_hash(),
+        format_expiry_time(cert.not_after().unwrap_or("".to_string()))
+    )
+}
+
+fn format_expiry_time(expiry_time: String) -> String {
+    let dt = DateTime::parse_from_rfc3339(expiry_time.as_str()).unwrap_or_else(|_| {
+        panic!("Failed to parse expiry time: {}", expiry_time);
+    });
+
+    let now = Local::now();
+    let duration = dt.signed_duration_since(now);
+
+    if duration.num_hours() < 0 {
+        "Expired".to_string()
+    } else if duration.num_hours() >= 24 {
+        format!("Expires in {} days", duration.num_days())
+    } else {
+        format!("Expires in {} hours", duration.num_hours())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+struct CertWithFormattedString {
+    cert: CageSigningCert,
+    formatted: String,
+    locked: bool,
+}
+
+impl CertWithFormattedString {
+    fn new(cert: &CageSigningCert, locked: bool) -> Self {
+        Self {
+            formatted: format_cert_for_multi_select(cert),
+            cert: cert.clone(),
+            locked,
+        }
+    }
+}
+
+async fn get_certs_for_selection(
+    cage_api: api::cage::CagesClient,
+    cage_uuid: &str,
+) -> Result<Vec<CertWithFormattedString>, CertError> {
+    let available_certs = match cage_api.get_signing_certs().await {
+        Ok(res) => res.certs,
+        Err(e) => {
+            log::error!("Error getting cage signing cert refs — {:?}", e);
+            return Err(CertError::ApiError(e));
+        }
+    };
+
+    let locked_certs = match cage_api.get_cage_locked_signing_certs(cage_uuid).await {
+        Ok(certs) => certs,
+        Err(e) => {
+            log::error!("Error getting cage signing cert — {:?}", e);
+            return Err(CertError::ApiError(e));
+        }
+    };
+
+    let locked_cert_uuids = locked_certs
+        .iter()
+        .map(|cert| cert.uuid())
+        .collect::<Vec<&str>>();
+
+    let available_stripped: Vec<&CageSigningCert> = available_certs
+        .iter()
+        .filter(|cert| !locked_cert_uuids.contains(&cert.uuid()))
+        .collect();
+
+    let available_formatted = available_stripped
+        .iter()
+        .map(|cert| CertWithFormattedString::new(cert, false))
+        .collect::<Vec<CertWithFormattedString>>();
+    let locked_formatted = locked_certs
+        .iter()
+        .map(|cert| CertWithFormattedString::new(cert, true))
+        .collect::<Vec<CertWithFormattedString>>();
+
+    let mut all_formatted: Vec<CertWithFormattedString> = vec![];
+
+    all_formatted.extend(available_formatted);
+    all_formatted.extend(locked_formatted);
+
+    Ok(all_formatted)
+}
+
+fn sort_certs_by_expiry(
+    mut certs: Vec<CertWithFormattedString>,
+) -> Result<Vec<CertWithFormattedString>, CertError> {
+    certs.sort_by_key(|cert| cert.cert.not_after().unwrap_or("".to_string()));
+    Ok(certs)
+}
+
+pub async fn lock_cage_to_certs(api_key: &str, cage_uuid: &str) -> Result<(), CertError> {
+    let cage_api = api::cage::CagesClient::new(AuthMode::ApiKey(api_key.to_string()));
+
+    let certs_for_select = get_certs_for_selection(cage_api.clone(), cage_uuid).await?;
+
+    let sorted_certs_for_select = sort_certs_by_expiry(certs_for_select)?;
+
+    let chosen: Vec<usize> = MultiSelect::new()
+        .with_prompt("Select Certs To Lock Cage To. Press Space To Select, Enter To Confirm")
+        .items_checked(
+            sorted_certs_for_select
+                .iter()
+                .map(|cert| (cert.formatted.as_str(), cert.locked))
+                .collect::<Vec<(&str, bool)>>()
+                .as_slice(),
+        )
+        .interact()?;
+
+    let chosen_cert_uuids = chosen
+        .iter()
+        .map(|index| {
+            sorted_certs_for_select
+                .get(*index)
+                .unwrap()
+                .cert
+                .uuid()
+                .to_string()
+        })
+        .collect::<Vec<String>>();
+
+    let payload = UpdateLockedCageSigningCertRequest::new(chosen_cert_uuids);
+
+    if let Err(e) = cage_api
+        .update_cage_locked_signing_certs(cage_uuid, payload)
+        .await
+    {
+        log::error!("Error locking cage to certs — {:?}", e);
+        return Err(CertError::ApiError(e));
+    };
+
+    Ok(())
 }
 
 fn add_distinguished_name_to_cert_params(
@@ -297,5 +442,58 @@ mod test {
 
         assert_eq!(expected_not_before, cert_validity_period.not_before);
         assert_eq!(expected_not_after, cert_validity_period.not_after);
+    }
+
+    #[test]
+    fn test_sort_certs_by_expiry() {
+        let cert1 = CageSigningCert::new(
+            None,
+            "uuid1".to_string(),
+            "app_uuid1".to_string(),
+            "hash1".to_string(),
+            None,
+            Some("2023-04-17T12:00:00Z".to_string()),
+        );
+        let cert2 = CageSigningCert::new(
+            None,
+            "uuid2".to_string(),
+            "app_uuid2".to_string(),
+            "hash2".to_string(),
+            None,
+            Some("2023-04-18T12:00:00Z".to_string()),
+        );
+        let cert3 = CageSigningCert::new(
+            None,
+            "uuid3".to_string(),
+            "app_uuid3".to_string(),
+            "hash3".to_string(),
+            None,
+            Some("2023-04-16T12:00:00Z".to_string()),
+        );
+
+        let certs = vec![
+            CertWithFormattedString::new(&cert1, false),
+            CertWithFormattedString::new(&cert2, false),
+            CertWithFormattedString::new(&cert3, false),
+        ];
+
+        let result = sort_certs_by_expiry(certs);
+
+        assert!(result.is_ok());
+        let sorted_certs = result.unwrap();
+
+        assert_eq!(sorted_certs.len(), 3);
+        assert_eq!(
+            sorted_certs[0].cert.not_after(),
+            Some("2023-04-16T12:00:00Z".to_string())
+        );
+        assert_eq!(
+            sorted_certs[1].cert.not_after(),
+            Some("2023-04-17T12:00:00Z".to_string())
+        );
+        assert_eq!(
+            sorted_certs[2].cert.not_after(),
+            Some("2023-04-18T12:00:00Z".to_string())
+        );
     }
 }

--- a/src/cli/cert.rs
+++ b/src/cli/cert.rs
@@ -151,9 +151,15 @@ pub async fn run(cert_args: CertArgs) -> exitcode::ExitCode {
             let api_key = get_api_key!();
 
             let cage_uuid = match CageConfig::try_from_filepath(&lock_cert_args.config) {
-                Ok(cage_config) if cage_config.uuid.is_some() => cage_config.uuid.unwrap(),
-                _ => {
-                    log::error!("No cage uuid found in cage.toml");
+                Ok(cage_config) => match cage_config.uuid {
+                    Some(uuid) => uuid,
+                    None => {
+                        log::error!("No cage uuid found in cage.toml");
+                        return DATAERR;
+                    }
+                },
+                Err(_) => {
+                    log::error!("Failed to load cage configuration");
                     return DATAERR;
                 }
             };


### PR DESCRIPTION
# Why
Need to provide users with the ability to lock down certs that can be used for a cage. 

# How
Add new interactive command which pulls in all active cert references from the API and allows the user to select which ones they want to lock their cage to use. 


https://user-images.githubusercontent.com/20796292/233643593-5df3f8b2-0ba3-43e9-a04e-4d0975f9d252.mov



