### PR TITLE
Add forward proxy protocol flag to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "attestation-doc-validation"
 version = "0.2.1"
-source = "registry+https://dl.cloudsmith.io/tREKUrB8e35qy9O7/evervault/rust-libraries/cargo/index.git"
+source = "sparse+https://cargo.cloudsmith.io/evervault/rust-libraries/"
 checksum = "5466fdcc164977f408c3f2c821b00003b97febb830e42c56cf267e3c9b2b6609"
 dependencies = [
  "aws-nitro-enclaves-cose",
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "rust-crypto"
 version = "0.1.24"
-source = "registry+https://dl.cloudsmith.io/tREKUrB8e35qy9O7/evervault/rust-libraries/cargo/index.git"
+source = "sparse+https://cargo.cloudsmith.io/evervault/rust-libraries/"
 checksum = "cee2de111fd94746e67580b021e64cc05bf776b4c2f776d5c965887a20768011"
 dependencies = [
  "base-x",

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -347,6 +347,7 @@ mod test {
             api_key_auth: true,
             trx_logging_enabled: true,
             runtime: None,
+            forward_proxy_protocol: false
         }
     }
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -243,6 +243,11 @@ async fn process_dockerfile<R: AsyncRead + std::marker::Unpin>(
         dataplane_info["egress"] = egress_settings;
     }
 
+    if build_config.forward_proxy_protocol {
+        dataplane_info["forward_proxy_protocol"] =
+            json!(&build_config.forward_proxy_protocol());
+    }
+
     let dataplane_env = format!(
         "echo {} > /etc/dataplane-config.json",
         dataplane_info.to_string().replace("\"", "\\\"")

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -244,8 +244,7 @@ async fn process_dockerfile<R: AsyncRead + std::marker::Unpin>(
     }
 
     if build_config.forward_proxy_protocol {
-        dataplane_info["forward_proxy_protocol"] =
-            json!(&build_config.forward_proxy_protocol());
+        dataplane_info["forward_proxy_protocol"] = json!(&build_config.forward_proxy_protocol());
     }
 
     let dataplane_env = format!(
@@ -347,7 +346,7 @@ mod test {
             api_key_auth: true,
             trx_logging_enabled: true,
             runtime: None,
-            forward_proxy_protocol: false
+            forward_proxy_protocol: false,
         }
     }
 

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -49,6 +49,10 @@ pub struct BuildArgs {
     /// Path to an enclave dockerfile to build from existing
     #[clap(long = "from-existing")]
     pub from_existing: Option<String>,
+
+    /// Enables forwarding proxy protocol when TLS Termination is disabled
+    #[clap(long = "forward-proxy-protocol")]
+    pub forward_proxy_protocol: bool,
 }
 
 impl BuildTimeConfig for BuildArgs {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -206,6 +206,7 @@ mod init_tests {
             trx_logging_disabled: false,
             egress_ports: Some("443".to_string()),
             egress_destinations: Some("evervault.com".to_string()),
+            forward_proxy_protocol: false,
         };
         init_local_config(init_args, sample_cage).await;
         let config_path = output_dir.path().join("cage.toml");

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -212,7 +212,6 @@ mod init_tests {
         let config_path = output_dir.path().join("cage.toml");
         assert!(config_path.exists());
         let config_content = String::from_utf8(read(config_path).unwrap()).unwrap();
-        println!("cage_config_content: {}", config_content);
         let expected_config_content = r#"name = "hello"
 uuid = "1234"
 app_uuid = "1234"
@@ -222,6 +221,7 @@ dockerfile = "Dockerfile"
 api_key_auth = true
 trx_logging = true
 disable_tls_termination = false
+forward_proxy_protocol = false
 
 [egress]
 enabled = true

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -71,6 +71,10 @@ pub struct InitArgs {
     /// Comma separated list of destinations to allow traffic to from the enclave e.g api.evervault.com, default is allow all
     #[clap(long = "egress-destinations")]
     pub egress_destinations: Option<String>,
+
+    /// Enables forwarding proxy protocol when TLS Termination is disabled
+    #[clap(long = "forward-proxy-protocol")]
+    pub forward_proxy_protocol: bool,
 }
 
 impl std::convert::From<InitArgs> for CageConfig {
@@ -102,6 +106,7 @@ impl std::convert::From<InitArgs> for CageConfig {
             api_key_auth: !val.disable_api_key_auth,
             trx_logging: !val.trx_logging_disabled,
             runtime: None,
+            forward_proxy_protocol: val.forward_proxy_protocol,
         }
     }
 }

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -118,12 +118,12 @@ pub async fn run(log_args: LogArgs) -> i32 {
             let instance_len = instance_id.len();
             let _ = instance_id.drain(0..instance_len - 6);
             format_timestamp(event.timestamp()).map(|timestamp| {
-              format!(
-                  "[ Instance-{} @ {} ] {}",
-                  instance_id,
-                  timestamp,
-                  event.message()
-              )
+                format!(
+                    "[ Instance-{} @ {} ] {}",
+                    instance_id,
+                    timestamp,
+                    event.message()
+                )
             })
         })
         .for_each(|log_event| {
@@ -145,5 +145,4 @@ fn format_timestamp(epoch: i64) -> Option<String> {
         .timestamp_opt(epoch_secs, epoch_nsecs as u32)
         .single()
         .map(|timestamp| timestamp.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
-        
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,6 +238,8 @@ pub struct CageConfig {
     pub signing: Option<SigningInfo>,
     pub attestation: Option<EIFMeasurements>,
     pub runtime: Option<RuntimeVersions>,
+    #[serde(default)]
+    pub forward_proxy_protocol: bool,
 }
 
 impl CageConfig {
@@ -270,6 +272,7 @@ pub struct ValidatedCageBuildConfig {
     pub api_key_auth: bool,
     pub trx_logging_enabled: bool,
     pub runtime: Option<RuntimeVersions>,
+    pub forward_proxy_protocol: bool,
 }
 
 impl ValidatedCageBuildConfig {
@@ -325,6 +328,10 @@ impl ValidatedCageBuildConfig {
 
     pub fn trx_logging_enabled(&self) -> bool {
         self.trx_logging_enabled
+    }
+
+    pub fn forward_proxy_protocol(&self) -> bool {
+        self.forward_proxy_protocol
     }
 }
 
@@ -445,6 +452,7 @@ impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
             api_key_auth: config.api_key_auth,
             trx_logging_enabled,
             runtime: config.runtime.clone(),
+            forward_proxy_protocol: config.forward_proxy_protocol,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -234,12 +234,13 @@ pub struct CageConfig {
     pub trx_logging: bool,
     #[serde(default)]
     pub disable_tls_termination: bool,
+    #[serde(default)]
+    pub forward_proxy_protocol: bool,
+    // Table configs
     pub egress: EgressSettings,
     pub signing: Option<SigningInfo>,
     pub attestation: Option<EIFMeasurements>,
     pub runtime: Option<RuntimeVersions>,
-    #[serde(default)]
-    pub forward_proxy_protocol: bool,
 }
 
 impl CageConfig {
@@ -547,8 +548,8 @@ mod test {
             attestation: None,
             api_key_auth: true,
             trx_logging: true,
-            runtime: None,
             forward_proxy_protocol: false,
+            runtime: None,
         };
 
         let test_args = ExampleArgs {

--- a/src/config.rs
+++ b/src/config.rs
@@ -548,6 +548,7 @@ mod test {
             api_key_auth: true,
             trx_logging: true,
             runtime: None,
+            forward_proxy_protocol: false,
         };
 
         let test_args = ExampleArgs {


### PR DESCRIPTION
# Why
With proxy protocol support being rolled out next week, we need to add support for PP to be forwarded to the user process when TLS termination is disabled.

# How
Add flag to CLI to pass proxy protocol through to the user process