### PR TITLE
Fix windows cli versioning

### DIFF
--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -146,6 +146,10 @@ jobs:
           target: ${{ env.WINDOWS_TARGET }}
           override: true
 
+      - name: Inject Version
+        run: |
+          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.version }}
+
       - name: Download cached dependencies
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
# Why
Windows cli action isn't injecting the version into the cargo file

# How
Start injecting the version
