### PR TITLE
Remove docker version warn until repro builds supported

### DIFF
--- a/src/docker/command.rs
+++ b/src/docker/command.rs
@@ -147,7 +147,7 @@ pub fn build_image_repro(
         ]
         .concat()
     } else {
-        log::warn!("Your docker version is too old for reproducible builds, attempting build without buildkit. Please upgrade docker for build reproducibility");
+        // log::warn!("Your docker version is too old for reproducible builds, attempting build without buildkit. Please upgrade docker for build reproducibility");
         [
             vec![
                 "build".as_ref(),


### PR DESCRIPTION
# Why
CLI is warning that docker version doesn't support reproducible build, it's currently not supported. Sling was misled by it.

# How
Comment out log for now
