### PR TITLE
track poll errors

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -4,7 +4,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use crate::api::cage::CagesClient;
 use crate::common::CliError;
 
-const MAX_SUCCESSIVE_POLLING_ERRORS: i32 = 10; // 10 attempts at 6sec intervals (1min)
+const MAX_SUCCESSIVE_POLLING_ERRORS: i32 = 5; // #attempts allowed at 6s intervals
 
 fn get_progress_bar(start_msg: &str, upload_len: Option<u64>) -> ProgressBar {
     match upload_len {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -178,12 +178,10 @@ where
             Err(e) => {
                 poll_err_count += 1;
 
-                if poll_err_count < MAX_SUCCESSIVE_POLLING_ERRORS {
-                    continue;
+                if poll_err_count > MAX_SUCCESSIVE_POLLING_ERRORS {
+                    progress_bar.finish();
+                    return Err(e);
                 }
-
-                progress_bar.finish();
-                return Err(e);
             }
         };
         tokio::time::sleep(std::time::Duration::from_millis(6000)).await;


### PR DESCRIPTION
# Why
We print errors if a polling error occurs, even if it's a one off

# How
Only print error if an error occurs on 10 requests in a row, ie after 1 minute of continuously failing polling

Not sure if that's a bit long
