### PR TITLE
Add arm support to release workflow

### DIFF
--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -57,9 +57,10 @@ jobs:
           . /etc/lsb-release
           sudo sed 's/deb http/deb \[arch=amd64\] http/' -i /etc/apt/sources.list
           sudo dpkg --add-architecture arm64
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse" >> /etc/apt/sources.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-security main universe restricted multiverse" >> /etc/apt/sources.list
+          sudo touch /etc/apt/sources.list.d/arm64.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse" >> /etc/apt/sources.list.d/arm64.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse" >> /etc/apt/sources.list.d/arm64.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-security main universe restricted multiverse" >> /etc/apt/sources.list.d/arm64.list
           apt update
           apt-get install musl-tools:arm64
 

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
-          toolchain: nightly
+          toolchain: nightly-${{ inputs.target }}
           command: build
           args: --release --target ${{ inputs.target }} -Z registry-auth
         env:

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -64,8 +64,8 @@ jobs:
           deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse
           deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-security main universe restricted multiverse
           EOF
-          apt update
-          apt-get install musl-tools:arm64
+          sudo apt update
+          sudo apt-get install musl-tools:arm64
 
       - name: Install musl-tools
         if: ${{ inputs.musl && inputs.musl_suffix == '' }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -18,9 +18,6 @@ on:
       version:
         required: true
         type: string
-      toolchain:
-        required: true
-        type: string
       vcpkgrs_dynamic:
         required: false
         type: number
@@ -76,6 +73,12 @@ jobs:
 
       - name: Install Rust
         run: rustup update --no-self-update stable && rustup default stable
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: ${{ inputs.profile }}
+          toolchain: nightly
+          target: ${{ inputs.target }}
           
       - name: Inject Version
         run: |
@@ -96,7 +99,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
-          toolchain: ${{ inputs.toolchain }}
+          toolchain: nightly
           command: build
           args: --release --target ${{ inputs.target }} -Z registry-auth
         env:

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup cross compilation
-        if: ${{ inputs.musl_suffix && inputs.platform == 'ubuntu-latest' }}
+        if: ${{ inputs.musl_suffix != '' && inputs.platform == 'ubuntu-latest' }}
         # Running /etc/lsb-release exports the DISTRIB_CODENAME variable which contains the OS codename used in ubuntu repositories
         # We then configure the existing apt sources to be scoped to amd64, and add the arm64 architecture sources before install musl-tools
         run: |

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          profile: ${{ inputs.platform }}
+          profile: ${{ inputs.profile }}
           toolchain: nightly
           target: ${{ inputs.target }}
           override: true

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -72,14 +72,8 @@ jobs:
         run: sudo apt-get install musl-tools
 
       - name: Install Rust
-        run: rustup update --no-self-update stable && rustup default stable
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: ${{ inputs.profile }}
-          toolchain: nightly
-          target: ${{ inputs.target }}
-          default: true
+        run: |
+          rustup update --no-self-update stable && rustup toolchain install nightly-${{ inputs.target }} --force-non-host
           
       - name: Inject Version
         run: |
@@ -96,13 +90,13 @@ jobs:
           mkdir ${{ env.BIN_DIR }}
           mkdir ${{ inputs.release_dir }}
 
+      - name: Install Cross
+        run: |
+          cargo install cross
+
       - name: Build CLI
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          toolchain: nightly
-          command: build
-          args: --release --target ${{ inputs.target }} -Z registry-auth
+        run: |
+          cross +nightly-${{ inputs.target }} build --release --target ${{ inputs.target }} -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -93,6 +93,8 @@ jobs:
       - name: Install Cross
         run: |
           cargo install cross
+          ls
+          cargo metadata || exit 1
 
       - name: Build CLI
         run: |

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -125,19 +125,3 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: ./${{ inputs.release_dir }}
-
-deb [arch=arm64] http://ports.ubuntu.com/ focal main restricted
-deb [arch=arm64] http://ports.ubuntu.com/ focal-updates main restricted
-deb [arch=arm64] http://ports.ubuntu.com/ focal universe
-deb [arch=arm64] http://ports.ubuntu.com/ focal-updates universe
-deb [arch=arm64] http://ports.ubuntu.com/ focal multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ focal-updates multiverse
-
-dpkg --add-architecture arm64
-sed 's/deb http/deb \[arch=amd64,i386\] http/' -i /etc/apt/sources.list
-echo >/etc/apt/sources.list <<EOF
-echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy main universe restricted multiverse" >> /etc/apt/sources.list
-echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main universe restricted multiverse" >> /etc/apt/sources.list
-echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy-security main universe restricted multiverse" >> /etc/apt/sources.list
-EOF
-apt update

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -57,9 +57,9 @@ jobs:
           . /etc/lsb-release
           sudo sed 's/deb http/deb \[arch=amd64\] http/' -i /etc/apt/sources.list
           sudo dpkg --add-architecture arm64
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse" >> /etc/apt/sources.list
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse" >> /etc/apt/sources.list
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-security main universe restricted multiverse" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse" >> /etc/apt/sources.list
+          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-security main universe restricted multiverse" >> /etc/apt/sources.list
           apt update
           apt-get install musl-tools:arm64
 

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -26,6 +26,10 @@ on:
         required: false
         type: boolean
         default: false
+      musl_suffix:
+        required: false
+        type: string
+        default: ''
       profile:
         required: false
         type: string
@@ -47,7 +51,7 @@ jobs:
 
       - name: Install musl-tools
         if: ${{ inputs.musl }}
-        run: sudo apt-get install musl-tools
+        run: sudo apt-get install musl-tools${{ inputs.musl_suffix }}
 
       - name: Install Rust
         run: rustup update --no-self-update stable && rustup default stable

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -34,6 +34,10 @@ on:
         required: false
         type: string
         default: 'default'
+      qemu:
+        required: false
+        type: boolean
+        default: false
     secrets:
       RUST_CRYPTO_REGISTRY:
         required: true
@@ -49,8 +53,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup cross compilation
-        if: ${{ inputs.musl && inputs.musl_suffix != '' && inputs.platform == 'ubuntu-latest' }}
+      - name: Setup Qemu
+        if: ${{ inputs.qemu }}
         # Running /etc/lsb-release exports the DISTRIB_CODENAME variable which contains the OS codename used in ubuntu repositories
         # We then configure the existing apt sources to be scoped to amd64, and add the arm64 architecture sources before install musl-tools
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -95,7 +95,10 @@ jobs:
           cargo install cross
           ls
           cargo metadata || exit 1
-
+        env:
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
+      
       - name: Build CLI
         run: |
           cross +nightly-${{ inputs.target }} build --release --target ${{ inputs.target }} -Z registry-auth

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -93,10 +93,17 @@ jobs:
       - name: Install Cross
         run: |
           cargo install cross
+          sudo mkdir .cargo
+          sudo chown $USER .cargo
+          sudo cat <<EOF > .cargo/config.toml
+          [registries.evervault-rust-libraries]
+          index = "${{ secrets.RUST_CRYPTO_AUTHENTICATED_REGISTRY_URL }}"
+          EOF
+          cargo +nightly metadata || exit 1
 
       - name: Build CLI
         run: |
-          cross +nightly build --release --target ${{ inputs.target }} -Z registry-auth --verbose
+          cross +nightly build --release --target ${{ inputs.target }} --verbose
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -93,13 +93,16 @@ jobs:
       - name: Install Cross
         run: |
           cargo install cross
-          ls
           sudo mkdir .cargo
           sudo chown $USER .cargo
           sudo cat <<EOF > .cargo/config.toml
           [registries.evervault-rust-libraries]
           index = "${{ secrets.RUST_CRYPTO_REGISTRY }}"
           token = "${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}"
+          EOF
+          sudo cat <<EOF > Cross.toml
+          [build.env]
+          passthrough = ["CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX=${{ secrets.RUST_CRYPTO_REGISTRY }}", "CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN=${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}"]
           EOF
 
       - name: Build CLI

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -79,6 +79,7 @@ jobs:
           profile: ${{ inputs.profile }}
           toolchain: nightly
           target: ${{ inputs.target }}
+          default: true
           
       - name: Inject Version
         run: |
@@ -99,7 +100,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
-          toolchain: nightly-${{ inputs.target }}
+          toolchain: nightly
           command: build
           args: --release --target ${{ inputs.target }} -Z registry-auth
         env:

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -58,6 +58,7 @@ jobs:
           sudo sed 's/deb http/deb \[arch=amd64\] http/' -i /etc/apt/sources.list
           sudo dpkg --add-architecture arm64
           sudo touch /etc/apt/sources.list.d/arm64.list
+          sudo chown $USER /etc/apt/sources.list.d/arm64.list
           sudo cat <<EOF > /etc/apt/sources.list.d/arm64.list
           deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse
           deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -26,6 +26,10 @@ on:
         required: false
         type: boolean
         default: false
+      profile:
+        required: false
+        type: string
+        default: 'default'
     secrets:
       RUST_CRYPTO_REGISTRY:
         required: true
@@ -50,6 +54,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
+          profile: ${{ inputs.platform }}
           toolchain: nightly
           target: ${{ inputs.target }}
           override: true
@@ -70,13 +75,23 @@ jobs:
           mkdir ${{ inputs.release_dir }}
 
       - name: Build CLI
-        run: |
-          cargo install cross
-          cross build --release --target ${{ inputs.target }} -Z registry-auth
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          toolchain: nightly
+          command: build
+          args: --release --target ${{ inputs.target }} -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-          CARGO_HOME: ${{ github.workspace }}/.cargo
+
+      - name: Compress macos binary
+        if: ${{ inputs.platform == 'macos-latest' }}
+        uses: svenstaro/upx-action@v2
+        with:
+          file: target/${{ inputs.target }}/release/ev-cage
+          args: --best --lzma
+          strip: true
 
       - name: Install 7zip
         if: ${{ inputs.platform == 'macos-latest' }}
@@ -85,7 +100,7 @@ jobs:
       - name: Compress Binary
         run: |
           mv ./target/${{ inputs.target }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ inputs.release_dir }}/ev-cage-${{ matrix.target }}-${{ inputs.version }}.tar.gz
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ inputs.release_dir }}/ev-cage-${{ inputs.target }}-${{ inputs.version }}.tar.gz
         
       - name: Upload as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -98,13 +98,11 @@ jobs:
           sudo chown $USER .cargo
           sudo cat <<EOF > .cargo/config.toml
           [registries.evervault-rust-libraries]
-          index = "$CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX"
-          token = "$CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN"
+          index = "${{ secrets.RUST_CRYPTO_REGISTRY }}"
+          token = "${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}"
           EOF
-          cargo metadata || exit 1
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
+          cargo +nightly-${{ inputs.target }} metadata -Z registry-auth || exit 1
+
       - name: Build CLI
         run: |
           cross +nightly-${{ inputs.target }} build --release --target ${{ inputs.target }} -Z registry-auth

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -93,21 +93,13 @@ jobs:
       - name: Install Cross
         run: |
           cargo install cross
-          sudo mkdir .cargo
-          sudo chown $USER .cargo
-          sudo cat <<EOF > .cargo/config.toml
-          [registries.evervault-rust-libraries]
-          index = "${{ secrets.RUST_CRYPTO_REGISTRY }}"
-          token = "${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}"
-          EOF
-          sudo cat <<EOF > Cross.toml
-          [build.env]
-          passthrough = ["CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX=${{ secrets.RUST_CRYPTO_REGISTRY }}", "CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN=${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}"]
-          EOF
 
       - name: Build CLI
         run: |
-          cross +nightly-${{ inputs.target }} build --release --target ${{ inputs.target }} -Z registry-auth
+          cross +nightly-${{ inputs.target }} build --release --target ${{ inputs.target }} -Z registry-auth --verbosse
+        env:
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 
       - name: Compress macos binary
         if: ${{ inputs.platform == 'macos-latest' }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -53,19 +53,9 @@ jobs:
         if: ${{ inputs.musl && inputs.musl_suffix != '' && inputs.platform == 'ubuntu-latest' }}
         # Running /etc/lsb-release exports the DISTRIB_CODENAME variable which contains the OS codename used in ubuntu repositories
         # We then configure the existing apt sources to be scoped to amd64, and add the arm64 architecture sources before install musl-tools
-        run: |
-          . /etc/lsb-release
-          sudo sed 's/deb http/deb \[arch=amd64\] http/' -i /etc/apt/sources.list
-          sudo dpkg --add-architecture arm64
-          sudo touch /etc/apt/sources.list.d/arm64.list
-          sudo chown $USER /etc/apt/sources.list.d/arm64.list
-          sudo cat <<EOF > /etc/apt/sources.list.d/arm64.list
-          deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse
-          deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse
-          deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-security main universe restricted multiverse
-          EOF
-          sudo apt update
-          sudo apt-get install musl-tools:arm64
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Install musl-tools
         if: ${{ inputs.musl && inputs.musl_suffix == '' }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -1,0 +1,95 @@
+---
+name: Compile CLI for Target
+on:
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+      release_dir:
+        required: true
+        type: string
+      artifact_name: 
+        required: true
+        type: string
+      platform:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      vcpkgrs_dynamic:
+        required: false
+        type: number
+        default: false
+      musl:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      RUST_CRYPTO_REGISTRY:
+        required: true
+      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN:
+        required: true
+jobs:
+  compile:
+    name: Compile CLI for ${{ inputs.target }}
+    runs-on: ${{ inputs.platform }}
+    env:
+      VCPKGRS_DYNAMIC: ${{ inputs.vcpkgrs_dynamic }}
+      BIN_DIR: bin
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install musl-tools
+        if: ${{ inputs.musl }}
+        run: sudo apt-get install musl-tools
+
+      - name: Install Rust
+        run: rustup update --no-self-update stable && rustup default stable
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: ${{ inputs.target }}
+          override: true
+          
+      - name: Inject Version
+        run: |
+          sh ./scripts/insert-cli-version.sh ${{ inputs.version }}
+      
+      - name: Download cached dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+            shared-key: "${{ inputs.target }}-cross-builds"
+
+      - name: Setup directories
+        shell: bash
+        run: |
+          mkdir ${{ env.BIN_DIR }}
+          mkdir ${{ inputs.release_dir }}
+
+      - name: Build CLI
+        run: |
+          cargo install cross
+          cross build --release --target ${{ inputs.target }} -Z registry-auth
+        env:
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
+          CARGO_HOME: ${{ github.workspace }}/.cargo
+
+      - name: Install 7zip
+        if: ${{ inputs.platform == 'macos-latest' }}
+        run: brew install p7zip
+      
+      - name: Compress Binary
+        run: |
+          mv ./target/${{ inputs.target }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ inputs.release_dir }}/ev-cage-${{ matrix.target }}-${{ inputs.version }}.tar.gz
+        
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ./${{ inputs.release_dir }}
+    

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -101,7 +101,6 @@ jobs:
           index = "${{ secrets.RUST_CRYPTO_REGISTRY }}"
           token = "${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}"
           EOF
-          cargo +nightly-${{ inputs.target }} metadata -Z registry-auth || exit 1
 
       - name: Build CLI
         run: |

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -99,7 +99,6 @@ jobs:
           [registries.evervault-rust-libraries]
           index = "${{ secrets.RUST_CRYPTO_AUTHENTICATED_REGISTRY_URL }}"
           EOF
-          cargo +nightly metadata || exit 1
 
       - name: Build CLI
         run: |

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -97,10 +97,8 @@ jobs:
           cargo install cross
           sudo mkdir .cargo
           sudo chown $USER .cargo
-          sudo cat <<EOF > .cargo/config.toml
-          [registries.evervault-rust-libraries]
-          index = "${{ secrets.RUST_CRYPTO_AUTHENTICATED_REGISTRY_URL }}"
-          EOF
+          sudo echo "[registries.evervault-rust-libraries]" >> .cargo/config.toml
+          sudo echo "index = \"${{ secrets.RUST_CRYPTO_AUTHENTICATED_REGISTRY_URL }}\"" >> .cargo/config.toml
 
       - name: Build CLI
         run: |

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -49,9 +49,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup cross compilation
+        if: ${{ inputs.musl_suffix && inputs.platform == 'ubuntu-latest' }}
+        # Running /etc/lsb-release exports the DISTRIB_CODENAME variable which contains the OS codename used in ubuntu repositories
+        # We then configure the existing apt sources to be scoped to amd64, and add the arm64 architecture sources before install musl-tools
+        run: |
+          . /etc/lsb-release
+          sed 's/deb http/deb \[arch=amd64\] http/' -i /etc/apt/sources.list
+          dpkg --add-architecture arm64
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse" >> /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse" >> /etc/apt/sources.list
+          echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-security main universe restricted multiverse" >> /etc/apt/sources.list
+          apt update
+          apt-get install musl-tools:arm64
+
       - name: Install musl-tools
-        if: ${{ inputs.musl }}
-        run: sudo apt-get install musl-tools${{ inputs.musl_suffix }}
+        if: ${{ inputs.musl && inputs.musl_suffix != '' }}
+        run: sudo apt-get install musl-tools
 
       - name: Install Rust
         run: rustup update --no-self-update stable && rustup default stable
@@ -111,4 +125,19 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: ./${{ inputs.release_dir }}
-    
+
+deb [arch=arm64] http://ports.ubuntu.com/ focal main restricted
+deb [arch=arm64] http://ports.ubuntu.com/ focal-updates main restricted
+deb [arch=arm64] http://ports.ubuntu.com/ focal universe
+deb [arch=arm64] http://ports.ubuntu.com/ focal-updates universe
+deb [arch=arm64] http://ports.ubuntu.com/ focal multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ focal-updates multiverse
+
+dpkg --add-architecture arm64
+sed 's/deb http/deb \[arch=amd64,i386\] http/' -i /etc/apt/sources.list
+echo >/etc/apt/sources.list <<EOF
+echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy main universe restricted multiverse" >> /etc/apt/sources.list
+echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main universe restricted multiverse" >> /etc/apt/sources.list
+echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy-security main universe restricted multiverse" >> /etc/apt/sources.list
+EOF
+apt update

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -94,12 +94,13 @@ jobs:
         run: |
           cargo install cross
           ls
-          cargo metadata -Z registry-auth || exit 1
+          sudo mkdir .cargo
           sudo cat <<EOF > .cargo/config.toml
           [registries.evervault-rust-libraries]
           index = "$CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX"
           token = "$CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN"
           EOF
+          cargo +nightly metadata -Z registry-auth || exit 1
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -105,9 +105,6 @@ jobs:
       - name: Build CLI
         run: |
           cross +nightly build --release --target ${{ inputs.target }} --verbose
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 
       - name: Compress macos binary
         if: ${{ inputs.platform == 'macos-latest' }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -58,9 +58,11 @@ jobs:
           sudo sed 's/deb http/deb \[arch=amd64\] http/' -i /etc/apt/sources.list
           sudo dpkg --add-architecture arm64
           sudo touch /etc/apt/sources.list.d/arm64.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse" >> /etc/apt/sources.list.d/arm64.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse" >> /etc/apt/sources.list.d/arm64.list
-          sudo echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-security main universe restricted multiverse" >> /etc/apt/sources.list.d/arm64.list
+          sudo cat <<EOF > /etc/apt/sources.list.d/arm64.list
+          deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse
+          deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse
+          deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-security main universe restricted multiverse
+          EOF
           apt update
           apt-get install musl-tools:arm64
 

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -76,13 +76,6 @@ jobs:
 
       - name: Install Rust
         run: rustup update --no-self-update stable && rustup default stable
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: ${{ inputs.profile }}
-          toolchain: ${{ inputs.toolchain }}
-          target: ${{ inputs.target }}
-          override: true
           
       - name: Inject Version
         run: |

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -21,7 +21,7 @@ on:
       vcpkgrs_dynamic:
         required: false
         type: number
-        default: false
+        default: 0
       musl:
         required: false
         type: boolean

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -95,12 +95,13 @@ jobs:
           cargo install cross
           ls
           sudo mkdir .cargo
+          sudo chown $USER .cargo
           sudo cat <<EOF > .cargo/config.toml
           [registries.evervault-rust-libraries]
           index = "$CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX"
           token = "$CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN"
           EOF
-          cargo +nightly metadata -Z registry-auth || exit 1
+          cargo +nightly metadata || exit 1
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -50,13 +50,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup cross compilation
-        if: ${{ inputs.musl_suffix != '' && inputs.platform == 'ubuntu-latest' }}
+        if: ${{ inputs.musl && inputs.musl_suffix != '' && inputs.platform == 'ubuntu-latest' }}
         # Running /etc/lsb-release exports the DISTRIB_CODENAME variable which contains the OS codename used in ubuntu repositories
         # We then configure the existing apt sources to be scoped to amd64, and add the arm64 architecture sources before install musl-tools
         run: |
           . /etc/lsb-release
           sudo sed 's/deb http/deb \[arch=amd64\] http/' -i /etc/apt/sources.list
-          dpkg --add-architecture arm64
+          sudo dpkg --add-architecture arm64
           echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse" >> /etc/apt/sources.list
           echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse" >> /etc/apt/sources.list
           echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-security main universe restricted multiverse" >> /etc/apt/sources.list
@@ -64,7 +64,7 @@ jobs:
           apt-get install musl-tools:arm64
 
       - name: Install musl-tools
-        if: ${{ inputs.musl && inputs.musl_suffix != '' }}
+        if: ${{ inputs.musl && inputs.musl_suffix == '' }}
         run: sudo apt-get install musl-tools
 
       - name: Install Rust

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update --no-self-update stable && rustup toolchain install nightly-${{ inputs.target }} --force-non-host
+          rustup update --no-self-update stable && rustup default stable && rustup toolchain install nightly-${{ inputs.target }} --force-non-host
           
       - name: Inject Version
         run: |
@@ -96,7 +96,7 @@ jobs:
 
       - name: Build CLI
         run: |
-          cross +nightly-${{ inputs.target }} build --release --target ${{ inputs.target }} -Z registry-auth --verbose
+          cross +nightly build --release --target ${{ inputs.target }} -Z registry-auth --verbose
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Build CLI
         run: |
-          cross +nightly-${{ inputs.target }} build --release --target ${{ inputs.target }} -Z registry-auth --verbosse
+          cross +nightly build --release --target ${{ inputs.target }} -Z registry-auth --verbose
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Build CLI
         run: |
-          cross +nightly build --release --target ${{ inputs.target }} -Z registry-auth --verbose
+          cross +nightly-${{ inputs.target }} build --release --target ${{ inputs.target }} -Z registry-auth --verbose
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -94,17 +94,18 @@ jobs:
         run: |
           cargo install cross
           ls
-          cargo metadata || exit 1
+          cargo metadata -Z registry-auth || exit 1
+          sudo cat <<EOF > .cargo/config.toml
+          [registries.evervault-rust-libraries]
+          index = "$CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX"
+          token = "$CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN"
+          EOF
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-      
       - name: Build CLI
         run: |
           cross +nightly-${{ inputs.target }} build --release --target ${{ inputs.target }} -Z registry-auth
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 
       - name: Compress macos binary
         if: ${{ inputs.platform == 'macos-latest' }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -55,7 +55,7 @@ jobs:
         # We then configure the existing apt sources to be scoped to amd64, and add the arm64 architecture sources before install musl-tools
         run: |
           . /etc/lsb-release
-          sed 's/deb http/deb \[arch=amd64\] http/' -i /etc/apt/sources.list
+          sudo sed 's/deb http/deb \[arch=amd64\] http/' -i /etc/apt/sources.list
           dpkg --add-architecture arm64
           echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME main universe restricted multiverse" >> /etc/apt/sources.list
           echo "deb [arch=arm64] http://ports.ubuntu.com/ $DISTRIB_CODENAME-updates main universe restricted multiverse" >> /etc/apt/sources.list

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -18,6 +18,9 @@ on:
       version:
         required: true
         type: string
+      toolchain:
+        required: true
+        type: string
       vcpkgrs_dynamic:
         required: false
         type: number
@@ -77,7 +80,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: ${{ inputs.profile }}
-          toolchain: nightly
+          toolchain: ${{ inputs.toolchain }}
           target: ${{ inputs.target }}
           override: true
           
@@ -100,7 +103,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           use-cross: true
-          toolchain: nightly
+          toolchain: ${{ inputs.toolchain }}
           command: build
           args: --release --target ${{ inputs.target }} -Z registry-auth
         env:

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -101,7 +101,7 @@ jobs:
           index = "$CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX"
           token = "$CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN"
           EOF
-          cargo +nightly metadata || exit 1
+          cargo metadata || exit 1
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/compile-cli-for-target.yml
+++ b/.github/workflows/compile-cli-for-target.yml
@@ -73,7 +73,9 @@ jobs:
 
       - name: Install Rust
         run: |
-          rustup update --no-self-update stable && rustup default stable && rustup toolchain install nightly-${{ inputs.target }} --force-non-host
+          rustup update --no-self-update stable && rustup default stable 
+          rustup toolchain install nightly
+          rustup target add ${{ inputs.target }}
           
       - name: Inject Version
         run: |

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -46,11 +46,13 @@ jobs:
             artifact_name: "linux-x86"
             platform: "ubuntu-latest"
             musl: true
+            profile: "minimal"
           - target: aarch64-unknown-linux-musl
             release_dir: "linux-arm64"
             artifact_name: "linux-arm64"
             platform: "ubuntu-latest"
             musl: true
+            profile: "minimal"
           - target: x86_64-apple-darwin
             release_dir: "apple-x86"
             artifact_name: "apple-x86"

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -48,7 +48,6 @@ jobs:
             platform: "ubuntu-latest"
             musl: true
             profile: "minimal"
-            toolchain: "nightly-x86_64-unknown-linux-musl"
           - target: aarch64-unknown-linux-musl
             release_dir: "linux-arm64"
             artifact_name: "linux-arm64"
@@ -56,29 +55,24 @@ jobs:
             musl: true
             musl_suffix: ":arm64"
             profile: "minimal"
-            toolchain: "nightly-aarch64-unknown-linux-musl"
           - target: x86_64-apple-darwin
             release_dir: "apple-x86"
             artifact_name: "apple-x86"
             platform: "macos-latest"
-            toolchain: "nightly-x86_64-apple-darwin"
           - target: aarch64-apple-darwin
             release_dir: "apple-arm64"
             artifact_name: "apple-arm64"
             platform: "macos-latest"
-            toolchain: "nightly-aarch64-apple-darwin"
           - target: x86_64-pc-windows-msvc
             release_dir: "windows-x86"
             artifact_name: "windows-x86"
             platform: "windows-latest"
             vcpkgrs_dynamic: 1
-            toolchain: "nightly-x86_64-pc-windows-msvc"
           - target: aarch64-pc-windows-msvc
             release_dir: "windows-arm64"
             artifact_name: "windows-arm64"
             platform: "windows-latest"
             vcpkgrs_dynamic: 1
-            toolchain: "nightly-aarch64-pc-windows-msvc"
     uses: ./.github/workflows/compile-cli-for-target.yml
     with:
       target: ${{ matrix.target }}
@@ -89,7 +83,6 @@ jobs:
       musl: ${{ matrix.musl }}
       musl_suffix: ${{ matrix.musl_suffix }}
       vcpkgrs_dynamic: ${{ matrix.vcpkgrs_dynamic }}
-      toolchain: ${{ matrix.toolchain }}
     secrets: inherit
 
   # release-cli-version:

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -25,10 +25,13 @@ jobs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
       - id: get-version
+        # run: |
+        #   echo "using version tag ${GITHUB_REF:11}"
+        #   echo "version=${GITHUB_REF:11}" >> "$GITHUB_OUTPUT"
         run: |
           echo "using version tag ${GITHUB_REF:11}"
-          echo ::set-output name=version::${GITHUB_REF:11}
-                
+          echo "version=v0.0.0" >> "$GITHUB_OUTPUT"
+
   compile-cli-for-target:
     needs: get-version
     strategy:

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -35,6 +35,9 @@ jobs:
       matrix:
         target: [ "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc" ]
         include:
+          # Set default for musl and vcpkgrs_dynamic, will be overridden for specific targets
+          - musl: false
+            vcpkgrs_dynamic: 0
           - target: x86_64-unknown-linux-musl
             release_dir: "linux-x86"
             artifact_name: "linux-x86"

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -48,6 +48,7 @@ jobs:
             platform: "ubuntu-latest"
             musl: true
             profile: "minimal"
+            toolchain: "nightly-x86_64-unknown-linux-musl"
           - target: aarch64-unknown-linux-musl
             release_dir: "linux-arm64"
             artifact_name: "linux-arm64"
@@ -55,24 +56,29 @@ jobs:
             musl: true
             musl_suffix: ":arm64"
             profile: "minimal"
+            toolchain: "nightly-aarch64-unknown-linux-musl"
           - target: x86_64-apple-darwin
             release_dir: "apple-x86"
             artifact_name: "apple-x86"
             platform: "macos-latest"
+            toolchain: "nightly-x86_64-apple-darwin"
           - target: aarch64-apple-darwin
             release_dir: "apple-arm64"
             artifact_name: "apple-arm64"
             platform: "macos-latest"
+            toolchain: "nightly-aarch64-apple-darwin"
           - target: x86_64-pc-windows-msvc
             release_dir: "windows-x86"
             artifact_name: "windows-x86"
             platform: "windows-latest"
             vcpkgrs_dynamic: 1
+            toolchain: "nightly-x86_64-pc-windows-msvc"
           - target: aarch64-pc-windows-msvc
             release_dir: "windows-arm64"
             artifact_name: "windows-arm64"
             platform: "windows-latest"
             vcpkgrs_dynamic: 1
+            toolchain: "nightly-aarch64-pc-windows-msvc"
     uses: ./.github/workflows/compile-cli-for-target.yml
     with:
       target: ${{ matrix.target }}
@@ -83,6 +89,7 @@ jobs:
       musl: ${{ matrix.musl }}
       musl_suffix: ${{ matrix.musl_suffix }}
       vcpkgrs_dynamic: ${{ matrix.vcpkgrs_dynamic }}
+      toolchain: ${{ matrix.toolchain }}
     secrets: inherit
 
   # release-cli-version:

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -2,9 +2,7 @@
 name: Release Cage CLI version
 
 on:
-  push:
-    tags:
-      - "v*"
+  push
 
 env:
   RUST_BACKTRACE: 1
@@ -119,113 +117,113 @@ jobs:
       RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
       CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 
-  release-cli-version:
-    needs: [ get-version, compile-linux-x86, compile-linux-arm64, compile-macos-x86, compile-macos-arm64, compile-windows-x86, compile-windows-arm64 ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create Release
-        id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.get-version.outputs.version }}
-          release_name: ${{ needs.get-version.outputs.version }}
+  # release-cli-version:
+  #   needs: [ get-version, compile-linux-x86, compile-linux-arm64, compile-macos-x86, compile-macos-arm64, compile-windows-x86, compile-windows-arm64 ]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Create Release
+  #       id: create-release
+  #       uses: actions/create-release@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         tag_name: ${{ needs.get-version.outputs.version }}
+  #         release_name: ${{ needs.get-version.outputs.version }}
       
-      - name: Download MacOS x86 Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: macos-x86
+  #     - name: Download MacOS x86 Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: macos-x86
 
-      - name: Download MacOS Arm Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: macos-arm64
+  #     - name: Download MacOS Arm Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: macos-arm64
       
-      - uses: cloudposse/github-action-matrix-outputs-read@v0.1.1
-        id: read-linux
-        with:
-          matrix-step-name: compile-ubuntu
+  #     - uses: cloudposse/github-action-matrix-outputs-read@v0.1.1
+  #       id: read-linux
+  #       with:
+  #         matrix-step-name: compile-ubuntu
 
-      - name: Download Linux x86 Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: linux-x86
+  #     - name: Download Linux x86 Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: linux-x86
 
-      - name: Download Linux Arm Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: linux-arm64
+  #     - name: Download Linux Arm Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: linux-arm64
 
-      - name: Download Windows x86 Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: windows-x86
+  #     - name: Download Windows x86 Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: windows-x86
 
-      - name: Download Windows Arm Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: windows-arm64
+  #     - name: Download Windows Arm Artifacts
+  #       uses: actions/download-artifact@v1
+  #       with:
+  #         name: windows-arm64
 
-      - name: Upload Linux x86 Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./linux-x86/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #     - name: Upload Linux x86 Release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #         asset_path: ./linux-x86/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #         asset_content_type: application/gzip
+  #         asset_name: ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-      - name: Upload Linux arm64 Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./linux-arm64/ev-cage-${{ env.LINUX_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.LINUX_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #     - name: Upload Linux arm64 Release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #         asset_path: ./linux-arm64/ev-cage-${{ env.LINUX_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #         asset_content_type: application/gzip
+  #         asset_name: ev-cage-${{ env.LINUX_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-      - name: Upload MacOS x86 Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./macos-x86/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #     - name: Upload MacOS x86 Release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #         asset_path: ./macos-x86/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #         asset_content_type: application/gzip
+  #         asset_name: ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-      - name: Upload MacOS arm64 Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./macos-arm64/ev-cage-${{ env.MACOS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.MACOS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #     - name: Upload MacOS arm64 Release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #         asset_path: ./macos-arm64/ev-cage-${{ env.MACOS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #         asset_content_type: application/gzip
+  #         asset_name: ev-cage-${{ env.MACOS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-      - name: Upload Windows x86 Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./windows-x86/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #     - name: Upload Windows x86 Release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #         asset_path: ./windows-x86/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #         asset_content_type: application/gzip
+  #         asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-      - name: Upload Windows arm64 Release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./windows-arm64/ev-cage-${{ env.WINDOWS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-          asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.WINDOWS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #     - name: Upload Windows arm64 Release
+  #       uses: actions/upload-release-asset@v1
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         upload_url: ${{ steps.create-release.outputs.upload_url }}
+  #         asset_path: ./windows-arm64/ev-cage-${{ env.WINDOWS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+  #         asset_content_type: application/gzip
+  #         asset_name: ev-cage-${{ env.WINDOWS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
   upload-artifacts-to-s3:
     needs: [ get-version, compile-linux-x86, compile-linux-arm64, compile-macos-x86, compile-macos-arm64, compile-windows-x86, compile-windows-arm64 ]
@@ -268,28 +266,43 @@ jobs:
         with:
           name: windows-arm64
 
-      - name: Upload Windows CLI to S3
+      - name: Validate artifacts exist as expected - Windows
         run: |
-          aws s3 cp ./windows-x86/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
-          aws s3 cp ./windows-arm64/ev-cage-${{ env.WINDOWS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_ARM_TARGET }}/ev-cage.tar.gz
+          ls ./windows-x86
+          ls ./windows-arm64
 
-      - name: Upload MacOS CLI to S3
+      - name: Validate artifacts exist as expected - Macos
         run: |
-          aws s3 cp ./macos-x86/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
-          aws s3 cp ./macos-arm64/ev-cage-${{ env.MACOS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_ARM_TARGET }}/ev-cage.tar.gz
+          ls ./macos-x86
+          ls ./macos-arm64
 
-      - name: Upload Linux CLI to S3
+      - name: Validate artifacts exist as expected - Linux
         run: |
-          aws s3 cp ./linux-x86/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
-          aws s3 cp ./linux-arm64/ev-cage-${{ env.LINUX_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_ARM_TARGET }}/ev-cage.tar.gz
+          ls ./linux-x86
+          ls ./linux-arm64
 
-      - uses: actions/checkout@v2
-      - name: Update install script in S3
-        run: |
-          sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.version }}
-          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/install
-          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/install
-          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/version
-          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/version
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/install"
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/version"
+      # - name: Upload Windows CLI to S3
+      #   run: |
+      #     aws s3 cp ./windows-x86/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
+      #     aws s3 cp ./windows-arm64/ev-cage-${{ env.WINDOWS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_ARM_TARGET }}/ev-cage.tar.gz
+
+      # - name: Upload MacOS CLI to S3
+      #   run: |
+      #     aws s3 cp ./macos-x86/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+      #     aws s3 cp ./macos-arm64/ev-cage-${{ env.MACOS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_ARM_TARGET }}/ev-cage.tar.gz
+
+      # - name: Upload Linux CLI to S3
+      #   run: |
+      #     aws s3 cp ./linux-x86/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
+      #     aws s3 cp ./linux-arm64/ev-cage-${{ env.LINUX_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_ARM_TARGET }}/ev-cage.tar.gz
+
+      # - uses: actions/checkout@v2
+      # - name: Update install script in S3
+      #   run: |
+      #     sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.version }}
+      #     aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/install
+      #     aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/install
+      #     aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/version
+      #     aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/version
+      #     aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/install"
+      #     aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/version"

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -30,7 +30,7 @@ jobs:
         #   echo "version=${GITHUB_REF:11}" >> "$GITHUB_OUTPUT"
         run: |
           echo "using version tag ${GITHUB_REF:11}"
-          echo "version=v0.0.0" >> "$GITHUB_OUTPUT"
+          echo "version=0.0.0" >> "$GITHUB_OUTPUT"
 
   compile-cli-for-target:
     needs: get-version

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -52,6 +52,7 @@ jobs:
             artifact_name: "linux-arm64"
             platform: "ubuntu-latest"
             musl: true
+            musl_suffix: ":arm64"
             profile: "minimal"
           - target: x86_64-apple-darwin
             release_dir: "apple-x86"

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -1,3 +1,4 @@
+---
 name: Release Cage CLI version
 
 on:
@@ -8,8 +9,11 @@ on:
 env:
   RUST_BACKTRACE: 1
   WINDOWS_TARGET: x86_64-pc-windows-msvc
+  WINDOWS_ARM_TARGET: aarch64-pc-windows-msvc
   MACOS_TARGET: x86_64-apple-darwin
+  MACOS_ARM_TARGET: aarch64-apple-darwin
   LINUX_TARGET: x86_64-unknown-linux-musl
+  LINUX_ARM_TARGET: x86_64-unknown-linux-musl
   STAGE: production
 
   # Directories to target during release
@@ -27,171 +31,98 @@ jobs:
           echo "using version tag ${GITHUB_REF:11}"
           echo ::set-output name=version::${GITHUB_REF:11}
                 
-  compile-ubuntu:
+  compile-linux-x86:
     runs-on: ubuntu-latest
     needs: get-version
-    steps:
-      - uses: actions/checkout@v2
+    uses: ./.github/workflows/compile-cli-for-target.yml
+    with:
+      target: ${{ env.LINUX_TARGET }}
+      release_dir: "linux-x86"
+      artifact_name: "linux_x86"
+      platform: "ubuntu-latest"
+      version: ${{ needs.get-version.outputs.version }}
+      musl: true
+    secrets:
+      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 
-      - name: Install musl-tools
-        run: sudo apt-get install musl-tools
-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          target: ${{ env.LINUX_TARGET }}
-
-      - name: Download cached dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-            shared-key: "linux-cross-builds"
-
-      - name: Install cross
-        run: cargo install cross
-
-      - name: Inject Version
-        run: |
-          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.version }}
-
-      - name: Build and Compress cli
-        run: |
-          mkdir ${{ env.BIN_DIR }}
-          mkdir ${{ env.RELEASE_DIR }}
-          cross build --release --target ${{ env.LINUX_TARGET }} -Z registry-auth
-          mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-          CARGO_HOME: ${{ github.workspace }}/.cargo
-
-      - name: Upload as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: linux
-          path: ./${{ env.RELEASE_DIR }}
-
-  compile-macos:
+  compile-linux-arm64:
+    runs-on: ubuntu-latest
+    needs: get-version
+    uses: ./.github/workflows/compile-cli-for-target.yml
+    with:
+      target: ${{ env.LINUX_ARM_TARGET } }}
+      release_dir: "linux-arm64"
+      artifact_name: "linux_arm64"
+      platform: "ubuntu-latest"
+      version: ${{ needs.get-version.outputs.version }}
+      musl: true
+    secrets:
+      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
+      
+  compile-macos-x86:
     runs-on: macos-latest
     needs: get-version
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Inject Version
-        run: |
-          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.version }}
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          target: ${{ env.MACOS_TARGET }}
-          override: true
-      
-      - name: Download cached dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-            shared-key: "macos-cross-builds"
-
-      - name: Build CLI MacOs Target
-        run: |
-          cargo install cross
-          cross build --release --target ${{ env.MACOS_TARGET }} -Z registry-auth
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-
-      - name: Compress macos binary
-        uses: svenstaro/upx-action@v2
-        with:
-          file: target/${{env.MACOS_TARGET}}/release/ev-cage
-          args: --best --lzma
-          strip: true
-
-      - name: Install 7z cli
-        run: brew install p7zip
-
-      - name: Setup directories
-        run: |
-          mkdir ${{ env.BIN_DIR }}
-          mkdir ${{ env.RELEASE_DIR }}
-
-      - name: Compress binary
-        run: |
-          mv target/${{env.MACOS_TARGET}}/release/ev-cage ${{ env.BIN_DIR }}/ev-cage
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ${{ env.RELEASE_DIR }}/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-
-      - name: Upload as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: macos
-          path: ./${{ env.RELEASE_DIR }}
-
-  compile-windows:
+    uses: ./.github/workflows/compile-cli-for-target.yml
+    with:
+      target: ${{ env.MACOS_TARGET }}
+      release_dir: "apple-x86"
+      artifact_name: "apple-x86"
+      platform: "macos-latest"
+      version: ${{ needs.get-version.outputs.version }}
+    secrets:
+      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
+    
+  compile-macos-arm64:
+    runs-on: macos-latest
+    needs: get-version
+    uses: ./.github/workflows/compile-cli-for-target.yml
+    with:
+      target: ${{ env.MACOS_ARM_TARGET }}
+      release_dir: "apple-arm64"
+      artifact_name: "apple-arm64"
+      platform: "macos-latest"
+      version: ${{ needs.get-version.outputs.version }}
+    secrets:
+      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
+    
+  compile-windows-x86:
     runs-on: windows-latest
     needs: get-version
-    env:
-      VCPKGRS_DYNAMIC: 1
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install Rust
-        run: rustup update --no-self-update stable && rustup default stable
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          target: ${{ env.WINDOWS_TARGET }}
-          override: true
-
-      - name: Inject Version
-        run: |
-          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.version }}
-
-      - name: Download cached dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-            shared-key: "windows-cross-builds"
-
-      - name: Fetch dependencies
-        run: cargo fetch -Z registry-auth
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-
-      - name: Build CLI for Windows
-        run: |
-          cargo install cross
-          cross build --release --target ${{ env.WINDOWS_TARGET }} -Z registry-auth
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-
-      - name: Setup directories
-        shell: bash
-        run: |
-          mkdir ${{ env.BIN_DIR }}
-          mkdir ${{ env.RELEASE_DIR }}
-
-      - name: Compress
-        shell: bash
-        run: |
-          mv target/${{ env.WINDOWS_TARGET }}/release/ev-cage.exe ${{ env.BIN_DIR }}/ev-cage.exe
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
-
-      - name: Upload as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: windows
-          path: ./${{ env.RELEASE_DIR }}
+    uses: ./.github/workflows/compile-cli-for-target.yml
+    with:
+      target: ${{ env.WINDOWS_TARGET }}
+      release_dir: "windows-x86"
+      artifact_name: "windows-x86"
+      platform: "windows-latest"
+      version: ${{ needs.get-version.outputs.version }}
+      vcpkgrs_dynamic: 1
+    secrets:
+      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
+    
+  compile-windows-arm64:
+    runs-on: windows-latest
+    needs: get-version
+    uses: ./.github/workflows/compile-cli-for-target.yml
+    with:
+      target: ${{ env.WINDOWS_ARM_TARGET }}
+      release_dir: "windows-arm64"
+      artifact_name: "windows-arm64"
+      platform: "windows-latest"
+      version: ${{ needs.get-version.outputs.version }}
+      vcpkgrs_dynamic: 1
+    secrets:
+      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 
   release-cli-version:
-    needs: [ get-version, compile-ubuntu, compile-macos, compile-windows ]
+    needs: [ get-version, compile-linux-x86, compile-linux-arm64, compile-macos-x86, compile-macos-arm64, compile-windows-x86, compile-windows-arm64 ]
     runs-on: ubuntu-latest
     steps:
-
       - name: Create Release
         id: create-release
         uses: actions/create-release@v1
@@ -200,57 +131,106 @@ jobs:
         with:
           tag_name: ${{ needs.get-version.outputs.version }}
           release_name: ${{ needs.get-version.outputs.version }}
-
-      - name: Download MacOS Artifacts
+      
+      - name: Download MacOS x86 Artifacts
         uses: actions/download-artifact@v1
         with:
-          name: macos
+          name: macos-x86
 
-      - name: Download Linux Artifacts
+      - name: Download MacOS Arm Artifacts
         uses: actions/download-artifact@v1
         with:
-          name: linux
+          name: macos-arm64
+      
+      - uses: cloudposse/github-action-matrix-outputs-read@v0.1.1
+        id: read-linux
+        with:
+          matrix-step-name: compile-ubuntu
 
-      - name: Download Windows Artifacts
+      - name: Download Linux x86 Artifacts
         uses: actions/download-artifact@v1
         with:
-          name: windows
+          name: linux-x86
 
-      - name: Upload Linux Release
+      - name: Download Linux Arm Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: linux-arm64
+
+      - name: Download Windows x86 Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: windows-x86
+
+      - name: Download Windows Arm Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: windows-arm64
+
+      - name: Upload Linux x86 Release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_path: ./linux-x86/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
           asset_content_type: application/gzip
           asset_name: ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-      - name: Upload MacOS Release
+      - name: Upload Linux arm64 Release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_path: ./linux-arm64/ev-cage-${{ env.LINUX_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: ev-cage-${{ env.LINUX_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+
+      - name: Upload MacOS x86 Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./macos-x86/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
           asset_content_type: application/gzip
           asset_name: ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
-      - name: Upload Windows Release
+      - name: Upload MacOS arm64 Release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_path: ./macos-arm64/ev-cage-${{ env.MACOS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: ev-cage-${{ env.MACOS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+
+      - name: Upload Windows x86 Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./windows-x86/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
           asset_content_type: application/gzip
           asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
+      - name: Upload Windows arm64 Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ./windows-arm64/ev-cage-${{ env.WINDOWS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_content_type: application/gzip
+          asset_name: ev-cage-${{ env.WINDOWS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+
   upload-artifacts-to-s3:
-    needs: [ get-version , compile-ubuntu, compile-macos, compile-windows ]
+    needs: [ get-version, compile-linux-x86, compile-linux-arm64, compile-macos-x86, compile-macos-arm64, compile-windows-x86, compile-windows-arm64 ]
     runs-on: ubuntu-latest
     steps:
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -258,32 +238,50 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Download MacOS Artifacts
+      - name: Download MacOS x86 Artifacts
         uses: actions/download-artifact@v1
         with:
-          name: macos
+          name: macos-x86
 
-      - name: Download Linux Artifacts
+      - name: Download MacOS arm64 Artifacts
         uses: actions/download-artifact@v1
         with:
-          name: linux
+          name: macos-arm64
 
-      - name: Download Windows Artifacts
+      - name: Download Linux x86 Artifacts
         uses: actions/download-artifact@v1
         with:
-          name: windows
+          name: linux-x86
+
+      - name: Download Linux arm64 Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: linux-arm64
+
+      - name: Download Windows x86 Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: windows-x86
+
+      - name: Download Windows arm64 Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: windows-arm64
 
       - name: Upload Windows CLI to S3
         run: |
-          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./windows-x86/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./windows-arm64/ev-cage-${{ env.WINDOWS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_ARM_TARGET }}/ev-cage.tar.gz
 
       - name: Upload MacOS CLI to S3
         run: |
-          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./macos-x86/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./macos-arm64/ev-cage-${{ env.MACOS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_ARM_TARGET }}/ev-cage.tar.gz
 
-      - name: Upload Ubuntu CLI to S3
+      - name: Upload Linux CLI to S3
         run: |
-          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./linux-x86/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./linux-arm64/ev-cage-${{ env.LINUX_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_ARM_TARGET }}/ev-cage.tar.gz
 
       - uses: actions/checkout@v2
       - name: Update install script in S3

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -11,7 +11,7 @@ env:
   MACOS_TARGET: x86_64-apple-darwin
   MACOS_ARM_TARGET: aarch64-apple-darwin
   LINUX_TARGET: x86_64-unknown-linux-musl
-  LINUX_ARM_TARGET: x86_64-unknown-linux-musl
+  LINUX_ARM_TARGET: aarch64-unknown-linux-musl
   STAGE: production
 
   # Directories to target during release
@@ -29,93 +29,50 @@ jobs:
           echo "using version tag ${GITHUB_REF:11}"
           echo ::set-output name=version::${GITHUB_REF:11}
                 
-  compile-linux-x86:
-    runs-on: ubuntu-latest
+  compile-cli-for-target:
     needs: get-version
+    strategy:
+      matrix:
+        target: [ "x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-pc-windows-msvc", "aarch64-pc-windows-msvc" ]
+        include:
+          - target: x86_64-unknown-linux-musl
+            release_dir: "linux-x86"
+            artifact_name: "linux-x86"
+            platform: "ubuntu-latest"
+            musl: true
+          - target: aarch64-unknown-linux-musl
+            release_dir: "linux-arm64"
+            artifact_name: "linux-arm64"
+            platform: "ubuntu-latest"
+            musl: true
+          - target: x86_64-apple-darwin
+            release_dir: "apple-x86"
+            artifact_name: "apple-x86"
+            platform: "macos-latest"
+          - target: aarch64-apple-darwin
+            release_dir: "apple-arm64"
+            artifact_name: "apple-arm64"
+            platform: "macos-latest"
+          - target: x86_64-pc-windows-msvc
+            release_dir: "windows-x86"
+            artifact_name: "windows-x86"
+            platform: "windows-latest"
+            vcpkgrs_dynamic: 1
+          - target: aarch64-pc-windows-msvc
+            release_dir: "windows-arm64"
+            artifact_name: "windows-arm64"
+            platform: "windows-latest"
+            vcpkgrs_dynamic: 1
     uses: ./.github/workflows/compile-cli-for-target.yml
     with:
-      target: ${{ env.LINUX_TARGET }}
-      release_dir: "linux-x86"
-      artifact_name: "linux_x86"
-      platform: "ubuntu-latest"
+      target: ${{ matrix.target }}
+      release_dir: ${{ matrix.release_dir }}
+      artifact_name: ${{ matrix.artifact_name }}
+      platform: ${{ matrix.platform }}
       version: ${{ needs.get-version.outputs.version }}
-      musl: true
-    secrets:
-      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-
-  compile-linux-arm64:
-    runs-on: ubuntu-latest
-    needs: get-version
-    uses: ./.github/workflows/compile-cli-for-target.yml
-    with:
-      target: ${{ env.LINUX_ARM_TARGET } }}
-      release_dir: "linux-arm64"
-      artifact_name: "linux_arm64"
-      platform: "ubuntu-latest"
-      version: ${{ needs.get-version.outputs.version }}
-      musl: true
-    secrets:
-      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-      
-  compile-macos-x86:
-    runs-on: macos-latest
-    needs: get-version
-    uses: ./.github/workflows/compile-cli-for-target.yml
-    with:
-      target: ${{ env.MACOS_TARGET }}
-      release_dir: "apple-x86"
-      artifact_name: "apple-x86"
-      platform: "macos-latest"
-      version: ${{ needs.get-version.outputs.version }}
-    secrets:
-      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-    
-  compile-macos-arm64:
-    runs-on: macos-latest
-    needs: get-version
-    uses: ./.github/workflows/compile-cli-for-target.yml
-    with:
-      target: ${{ env.MACOS_ARM_TARGET }}
-      release_dir: "apple-arm64"
-      artifact_name: "apple-arm64"
-      platform: "macos-latest"
-      version: ${{ needs.get-version.outputs.version }}
-    secrets:
-      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-    
-  compile-windows-x86:
-    runs-on: windows-latest
-    needs: get-version
-    uses: ./.github/workflows/compile-cli-for-target.yml
-    with:
-      target: ${{ env.WINDOWS_TARGET }}
-      release_dir: "windows-x86"
-      artifact_name: "windows-x86"
-      platform: "windows-latest"
-      version: ${{ needs.get-version.outputs.version }}
-      vcpkgrs_dynamic: 1
-    secrets:
-      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-    
-  compile-windows-arm64:
-    runs-on: windows-latest
-    needs: get-version
-    uses: ./.github/workflows/compile-cli-for-target.yml
-    with:
-      target: ${{ env.WINDOWS_ARM_TARGET }}
-      release_dir: "windows-arm64"
-      artifact_name: "windows-arm64"
-      platform: "windows-latest"
-      version: ${{ needs.get-version.outputs.version }}
-      vcpkgrs_dynamic: 1
-    secrets:
-      RUST_CRYPTO_REGISTRY: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-      CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
+      musl: ${{ matrix.musl }}
+      vcpkgrs_dynamic: ${{ matrix.vcpkgrs_dynamic }}
+    secrets: inherit
 
   # release-cli-version:
   #   needs: [ get-version, compile-linux-x86, compile-linux-arm64, compile-macos-x86, compile-macos-arm64, compile-windows-x86, compile-windows-arm64 ]
@@ -226,7 +183,7 @@ jobs:
   #         asset_name: ev-cage-${{ env.WINDOWS_ARM_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
 
   upload-artifacts-to-s3:
-    needs: [ get-version, compile-linux-x86, compile-linux-arm64, compile-macos-x86, compile-macos-arm64, compile-windows-x86, compile-windows-arm64 ]
+    needs: [ get-version, compile-cli-for-target ]
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -55,6 +55,7 @@ jobs:
             musl: true
             musl_suffix: ":arm64"
             profile: "minimal"
+            qemu: true
           - target: x86_64-apple-darwin
             release_dir: "apple-x86"
             artifact_name: "apple-x86"
@@ -63,6 +64,7 @@ jobs:
             release_dir: "apple-arm64"
             artifact_name: "apple-arm64"
             platform: "macos-latest"
+            qemu: true
           - target: x86_64-pc-windows-msvc
             release_dir: "windows-x86"
             artifact_name: "windows-x86"
@@ -73,6 +75,7 @@ jobs:
             artifact_name: "windows-arm64"
             platform: "windows-latest"
             vcpkgrs_dynamic: 1
+            qemu: true
     uses: ./.github/workflows/compile-cli-for-target.yml
     with:
       target: ${{ matrix.target }}
@@ -83,6 +86,7 @@ jobs:
       musl: ${{ matrix.musl }}
       musl_suffix: ${{ matrix.musl_suffix }}
       vcpkgrs_dynamic: ${{ matrix.vcpkgrs_dynamic }}
+      qemu: ${{ matrix.qemu }}
     secrets: inherit
 
   # release-cli-version:

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -41,6 +41,7 @@ jobs:
           # Set default for musl and vcpkgrs_dynamic, will be overridden for specific targets
           - musl: false
             vcpkgrs_dynamic: 0
+            musl_suffix: ""
           - target: x86_64-unknown-linux-musl
             release_dir: "linux-x86"
             artifact_name: "linux-x86"
@@ -80,6 +81,7 @@ jobs:
       platform: ${{ matrix.platform }}
       version: ${{ needs.get-version.outputs.version }}
       musl: ${{ matrix.musl }}
+      musl_suffix: ${{ matrix.musl_suffix }}
       vcpkgrs_dynamic: ${{ matrix.vcpkgrs_dynamic }}
     secrets: inherit
 

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -42,6 +42,7 @@ jobs:
           - musl: false
             vcpkgrs_dynamic: 0
             musl_suffix: ""
+            qemu: false
           - target: x86_64-unknown-linux-musl
             release_dir: "linux-x86"
             artifact_name: "linux-x86"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "attestation-doc-validation"
 version = "0.2.1"
-source = "sparse+https://cargo.cloudsmith.io/evervault/rust-libraries/"
+source = "registry+https://dl.cloudsmith.io/tREKUrB8e35qy9O7/evervault/rust-libraries/cargo/index.git"
 checksum = "5466fdcc164977f408c3f2c821b00003b97febb830e42c56cf267e3c9b2b6609"
 dependencies = [
  "aws-nitro-enclaves-cose",
@@ -1798,9 +1798,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -2052,7 +2052,7 @@ dependencies = [
 [[package]]
 name = "rust-crypto"
 version = "0.1.24"
-source = "sparse+https://cargo.cloudsmith.io/evervault/rust-libraries/"
+source = "registry+https://dl.cloudsmith.io/tREKUrB8e35qy9O7/evervault/rust-libraries/cargo/index.git"
 checksum = "cee2de111fd94746e67580b021e64cc05bf776b4c2f776d5c965887a20768011"
 dependencies = [
  "base-x",


### PR DESCRIPTION
# Why
Release workflow only includes x86 assets. We should include arm

# How
- Split the compilation step out into a reusable action
- Use new compilation action to build arm and x86 binaries for the CLI
- Deploy both binaries to S3.
