### PR TITLE
markd/turn off repro builds feature flagging

### DIFF
--- a/.github/workflows/lint-and-test-cli.yml
+++ b/.github/workflows/lint-and-test-cli.yml
@@ -25,7 +25,7 @@ jobs:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
       - name: Test project
-        run: cargo test -p ev-cage --features repro_builds
+        run: cargo test -p ev-cage
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
       - name: Format project

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +792,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "thiserror",
@@ -2285,6 +2299,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,3 @@ tokio-test = "0.4.2"
 [target.'cfg(unix)'.dependencies]
 aws-nitro-enclaves-nsm-api = { version = "0.2.1" }
 attestation-doc-validation = { version = "0.2.0", registry="evervault-rust-libraries" }
-
-[features]
-repro_builds = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ sha2 = "0.9.9"
 git2 = "0.17.1"
 version-compare = "0.1.1"
 regex = "1.8.1"
+serial_test = "2.0.0"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/README.md
+++ b/README.md
@@ -9,29 +9,6 @@ The Evervault Cages product is open source with the aim of providing transparenc
 
 The current state of this project does not allow for self-hosting. We plan on addressing this by abstracting away the Evervault-specific elements of the Cages product.
 
-## Try out Reproducible Builds
-
-Reproducible builds will stay in the experimental phase until the release of Buildkit v0.12 which is expected in the next few weeks.
-
-We have implemented the work arounds for reproducible builds from this [blog post](https://medium.com/nttlabs/bit-for-bit-reproducible-builds-with-dockerfile-7cc2b9faed9f). These workout arounds won't be needed in v0.12 so we are going to wait till then to merge the feature into the CLI.
-
-To try out the feature now:
-```
-cargo build --features repro_builds
-sudo ln -s ${PROJECT_DIR}/target/debug/ev-cage /usr/local/bin/ev-cage
-```
-
-Build a Cage:
-```
-ev-cage init --name test-repro-builds
-ev-cage build
-```
-
-Reproduce the same Cage anywhere:
-```
-ev-cage build --from-existing enclave.Dockerfile
-```
-
 ## Subcommands
 
 ### init

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -692,6 +692,7 @@ ENTRYPOINT ["/bootstrap", "1>&2"]
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_choose_output_dir() {
         let output_dir = TempDir::new().unwrap();
 

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -45,7 +45,6 @@ pub struct BuildArgs {
     #[clap(long = "build-arg")]
     pub docker_build_args: Vec<String>,
 
-    #[cfg(feature = "repro_builds")]
     /// Path to an enclave dockerfile to build from existing
     #[clap(long = "from-existing")]
     pub from_existing: Option<String>,
@@ -111,9 +110,6 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
 
     let runtime_info = RuntimeVersions::new(data_plane_version.clone(), installer_version.clone());
 
-    #[cfg(not(feature = "repro_builds"))]
-    let from_existing = None;
-    #[cfg(feature = "repro_builds")]
     let from_existing = build_args.from_existing;
     let built_enclave = match build_enclave_image_file(
         &validated_config,

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -49,7 +49,6 @@ pub struct DeployArgs {
     #[clap(long = "build-arg")]
     pub docker_build_args: Vec<String>,
 
-    #[cfg(feature = "repro_builds")]
     /// Path to an enclave dockerfile to build from existing
     #[clap(long = "from-existing")]
     pub from_existing: Option<String>,
@@ -106,9 +105,6 @@ pub async fn run(deploy_args: DeployArgs) -> exitcode::ExitCode {
             }
         };
 
-    #[cfg(not(feature = "repro_builds"))]
-    let from_existing = None;
-    #[cfg(feature = "repro_builds")]
     let from_existing = deploy_args.from_existing;
     let (eif_measurements, output_path) = match resolve_eif(
         &validated_config,

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -282,7 +282,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature = "repro_builds")]
     async fn test_reproducible_cage_builds_with_pinned_version() {
         let current_dir = std::env::current_dir().unwrap();
         let (build_output, output_path) = test_utils::build_test_cage(
@@ -297,7 +296,7 @@ mod tests {
         let expected_pcrs: PCRs = serde_json::from_str(r#"{
             "PCR0": "4d99ce0096bffeea435c41016e9d64aa51caae95d7846fb7c8708f590d31be1fc704adc13bedabbcb2980d6612dde6e9",
             "PCR1": "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f",
-            "PCR2": "42997b22af1f96a6b32372402af03a5d16e47316e7990314bdb01c0759fa11a7ae88e3ae2f3628b1c1ab734ea2f2ba34"
+            "PCR2": "e44d206c46d1f41dd4a5333c8374612b567940737f90d64f332d69d9598614ff95d1696d6af03dd005946a25c5c52ed9"
         }"#).unwrap();
         assert_eq!(&eif_pcrs.pcr0, &expected_pcrs.pcr0);
         assert_eq!(&eif_pcrs.pcr1, &expected_pcrs.pcr1);

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -296,7 +296,7 @@ mod tests {
         let expected_pcrs: PCRs = serde_json::from_str(r#"{
             "PCR0": "4d99ce0096bffeea435c41016e9d64aa51caae95d7846fb7c8708f590d31be1fc704adc13bedabbcb2980d6612dde6e9",
             "PCR1": "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f",
-            "PCR2": "e44d206c46d1f41dd4a5333c8374612b567940737f90d64f332d69d9598614ff95d1696d6af03dd005946a25c5c52ed9"
+            "PCR2": "42997b22af1f96a6b32372402af03a5d16e47316e7990314bdb01c0759fa11a7ae88e3ae2f3628b1c1ab734ea2f2ba34"
         }"#).unwrap();
         assert_eq!(&eif_pcrs.pcr0, &expected_pcrs.pcr0);
         assert_eq!(&eif_pcrs.pcr1, &expected_pcrs.pcr1);

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -282,6 +282,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_reproducible_cage_builds_with_pinned_version() {
         let current_dir = std::env::current_dir().unwrap();
         let (build_output, output_path) = test_utils::build_test_cage(

--- a/src/docker/command.rs
+++ b/src/docker/command.rs
@@ -48,7 +48,6 @@ pub fn load_image_into_local_docker_registry(
     Ok(docker_load_result)
 }
 
-#[cfg(feature = "repro_builds")]
 fn docker_buildkit_enabled() -> Result<bool, CommandError> {
     use regex::Regex;
     use version_compare::Version;
@@ -65,11 +64,6 @@ fn docker_buildkit_enabled() -> Result<bool, CommandError> {
     let min_version = Version::from("0.10.0").ok_or(CommandError::SemverParseError)?;
     let user_version = Version::from(&semver_match).ok_or(CommandError::SemverParseError)?;
     Ok(user_version >= min_version)
-}
-
-#[cfg(not(feature = "repro_builds"))]
-fn docker_buildkit_enabled() -> Result<bool, CommandError> {
-    Ok(false)
 }
 
 pub fn get_git_hash() -> String {

--- a/src/docker/command.rs
+++ b/src/docker/command.rs
@@ -141,7 +141,7 @@ pub fn build_image_repro(
         ]
         .concat()
     } else {
-        // log::warn!("Your docker version is too old for reproducible builds, attempting build without buildkit. Please upgrade docker for build reproducibility");
+        log::warn!("Your docker version is too old for reproducible builds, attempting build without buildkit. Please upgrade docker for build reproducibility");
         [
             vec![
                 "build".as_ref(),

--- a/src/docker/parse.rs
+++ b/src/docker/parse.rs
@@ -357,6 +357,10 @@ impl TryFrom<&[u8]> for Directive {
         }
 
         let directive = match directive_str.to_ascii_uppercase().as_str() {
+            "ADD" => Self::Add {
+                source_url: String::new(),
+                destination_path: String::new(),
+            },
             "ENTRYPOINT" => Self::Entrypoint {
                 mode: None,
                 tokens: Vec::new(),

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -5,6 +5,9 @@ use crate::common::OutputPath;
 use crate::config::{read_and_validate_config, ValidatedCageBuildConfig};
 use crate::enclave::BuiltEnclave;
 
+// anytime this is called by a test, the test should be run sequentially
+// using the #[serial_test::serial] macro, this prevents issues with conflicting
+// eifs throwing PCRs off in repro builds
 pub async fn build_test_cage(
     output_dir: Option<&str>,
     from_existing: Option<String>,

--- a/test.cage.toml
+++ b/test.cage.toml
@@ -7,6 +7,7 @@ dockerfile = "./sample-user.Dockerfile"
 api_key_auth = true
 trx_logging = true
 disable_tls_termination = false
+forward_proxy_protocol = false
 
 [egress]
 enabled = false
@@ -20,8 +21,8 @@ HashAlgorithm = "Sha384 { ... }"
 PCR0 = "4d99ce0096bffeea435c41016e9d64aa51caae95d7846fb7c8708f590d31be1fc704adc13bedabbcb2980d6612dde6e9"
 PCR1 = "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f"
 PCR2 = "42997b22af1f96a6b32372402af03a5d16e47316e7990314bdb01c0759fa11a7ae88e3ae2f3628b1c1ab734ea2f2ba34"
-PCR8 = "7c898f1dfd7983c8824af69b4fa693812236a7aedf3a7b13488d710250c0ac29cbe8748a29e49473779b1f568204bb81"
+PCR8 = "e17f6163fad2b52657fbd3ea4e55f4df0cb1baeba2a76ca27b1d4b78531a00069ed9510319d24e1d080bcaefcd0690a1"
 
 [runtime]
-data_plane_version = "0.0.31"
+data_plane_version = "0.0.37"
 installer_version = "b8073166b7c5bc8fe2abf192f66e1106f2d4be547b1841be69f95ff2c4ea578c"


### PR DESCRIPTION
# Why
Since #21 we're removing any ENV directives from dockerfiles (now setting any assignment in the user script). This allows repro builds to function

# How
Revert [472312d4ad34cade02424128e8c7bf246cac8eb6](https://github.com/evervault/cage-cli/commit/472312d4ad34cade02424128e8c7bf246cac8eb6) by hand
