### PR TITLE
Add trusted headers to cage cli

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -257,6 +257,10 @@ async fn process_dockerfile<R: AsyncRead + std::marker::Unpin>(
         dataplane_info["forward_proxy_protocol"] = json!(&build_config.forward_proxy_protocol());
     }
 
+    if !build_config.trusted_headers().is_empty() {
+      dataplane_info["trusted_headers"] = json!(build_config.trusted_headers());
+    }
+
     let dataplane_env = format!(
         "echo {} > /etc/dataplane-config.json",
         dataplane_info.to_string().replace("\"", "\\\"")
@@ -413,6 +417,7 @@ mod test {
             trx_logging_enabled: true,
             runtime: None,
             forward_proxy_protocol: false,
+            trusted_headers: vec!["X-Evervault-*".to_string()]
         }
     }
 
@@ -447,7 +452,7 @@ USER root
 RUN mkdir -p /opt/evervault
 ADD https://cage-build-assets.evervault.com/installer/abcdef.tar.gz /opt/evervault/runtime-dependencies.tar.gz
 RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
-RUN echo {\"api_key_auth\":true,\"trx_logging_enabled\":true} > /etc/dataplane-config.json
+RUN echo {\"api_key_auth\":true,\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
 RUN mkdir -p /etc/service/user-entrypoint
 RUN printf "#!/bin/sh\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_CAGE_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
 ADD https://cage-build-assets.evervault.com/runtime/0.0.0/data-plane/egress-disabled/tls-termination-enabled /opt/evervault/data-plane
@@ -539,7 +544,7 @@ USER root
 RUN mkdir -p /opt/evervault
 ADD https://cage-build-assets.evervault.com/installer/abcdef.tar.gz /opt/evervault/runtime-dependencies.tar.gz
 RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
-RUN echo {\"api_key_auth\":true,\"trx_logging_enabled\":true} > /etc/dataplane-config.json
+RUN echo {\"api_key_auth\":true,\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
 RUN mkdir -p /etc/service/user-entrypoint
 RUN printf "#!/bin/sh\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_CAGE_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
 ADD https://cage-build-assets.evervault.com/runtime/0.0.0/data-plane/egress-disabled/tls-termination-enabled /opt/evervault/data-plane
@@ -602,7 +607,7 @@ USER root
 RUN mkdir -p /opt/evervault
 ADD https://cage-build-assets.evervault.com/installer/abcdef.tar.gz /opt/evervault/runtime-dependencies.tar.gz
 RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
-RUN echo {\"api_key_auth\":true,\"trx_logging_enabled\":true} > /etc/dataplane-config.json
+RUN echo {\"api_key_auth\":true,\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
 RUN mkdir -p /etc/service/user-entrypoint
 RUN printf "#!/bin/sh\nsu someuser\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_CAGE_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
 ADD https://cage-build-assets.evervault.com/runtime/0.0.0/data-plane/egress-disabled/tls-termination-enabled /opt/evervault/data-plane
@@ -666,7 +671,7 @@ USER root
 RUN mkdir -p /opt/evervault
 ADD https://cage-build-assets.evervault.com/installer/abcdef.tar.gz /opt/evervault/runtime-dependencies.tar.gz
 RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
-RUN echo {\"api_key_auth\":true,\"trx_logging_enabled\":true} > /etc/dataplane-config.json
+RUN echo {\"api_key_auth\":true,\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
 RUN mkdir -p /etc/service/user-entrypoint
 RUN printf "#!/bin/sh\nexport Hello=World Ever=Vault Cages=Secure CRAB=Ferris\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_CAGE_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
 ADD https://cage-build-assets.evervault.com/runtime/0.0.0/data-plane/egress-disabled/tls-termination-enabled /opt/evervault/data-plane

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -258,7 +258,7 @@ async fn process_dockerfile<R: AsyncRead + std::marker::Unpin>(
     }
 
     if !build_config.trusted_headers().is_empty() {
-      dataplane_info["trusted_headers"] = json!(build_config.trusted_headers());
+        dataplane_info["trusted_headers"] = json!(build_config.trusted_headers());
     }
 
     let dataplane_env = format!(
@@ -417,7 +417,7 @@ mod test {
             trx_logging_enabled: true,
             runtime: None,
             forward_proxy_protocol: false,
-            trusted_headers: vec!["X-Evervault-*".to_string()]
+            trusted_headers: vec!["X-Evervault-*".to_string()],
         }
     }
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -212,7 +212,7 @@ mod init_tests {
             egress_ports: Some("443".to_string()),
             egress_destinations: Some("evervault.com".to_string()),
             forward_proxy_protocol: false,
-            trusted_headers: Some("X-Evervault-*".to_string())
+            trusted_headers: Some("X-Evervault-*".to_string()),
         };
         init_local_config(init_args, sample_cage).await;
         let config_path = output_dir.path().join("cage.toml");

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -75,6 +75,10 @@ pub struct InitArgs {
     /// Enables forwarding proxy protocol when TLS Termination is disabled
     #[clap(long = "forward-proxy-protocol")]
     pub forward_proxy_protocol: bool,
+
+    /// Trusted headers sent into the Cage will be persisted without redaction in the Cage's transaction logs
+    #[clap(long = "trusted_headers")]
+    pub trusted_headers: Option<String>,
 }
 
 impl std::convert::From<InitArgs> for CageConfig {
@@ -107,6 +111,7 @@ impl std::convert::From<InitArgs> for CageConfig {
             trx_logging: !val.trx_logging_disabled,
             runtime: None,
             forward_proxy_protocol: val.forward_proxy_protocol,
+            trusted_headers: convert_comma_list(val.trusted_headers).unwrap_or_else(|| vec![]),
         }
     }
 }
@@ -207,6 +212,7 @@ mod init_tests {
             egress_ports: Some("443".to_string()),
             egress_destinations: Some("evervault.com".to_string()),
             forward_proxy_protocol: false,
+            trusted_headers: Some("X-Evervault-*".to_string())
         };
         init_local_config(init_args, sample_cage).await;
         let config_path = output_dir.path().join("cage.toml");
@@ -222,6 +228,7 @@ api_key_auth = true
 trx_logging = true
 disable_tls_termination = false
 forward_proxy_protocol = false
+trusted_headers = ["X-Evervault-*"]
 
 [egress]
 enabled = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -236,6 +236,8 @@ pub struct CageConfig {
     pub disable_tls_termination: bool,
     #[serde(default)]
     pub forward_proxy_protocol: bool,
+    #[serde(default)]
+    pub trusted_headers: Vec<String>,
     // Table configs
     pub egress: EgressSettings,
     pub signing: Option<SigningInfo>,
@@ -274,6 +276,7 @@ pub struct ValidatedCageBuildConfig {
     pub trx_logging_enabled: bool,
     pub runtime: Option<RuntimeVersions>,
     pub forward_proxy_protocol: bool,
+    pub trusted_headers: Vec<String>,
 }
 
 impl ValidatedCageBuildConfig {
@@ -333,6 +336,10 @@ impl ValidatedCageBuildConfig {
 
     pub fn forward_proxy_protocol(&self) -> bool {
         self.forward_proxy_protocol
+    }
+
+    pub fn trusted_headers(&self) -> &[String] {
+      &self.trusted_headers
     }
 }
 
@@ -454,6 +461,7 @@ impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
             trx_logging_enabled,
             runtime: config.runtime.clone(),
             forward_proxy_protocol: config.forward_proxy_protocol,
+            trusted_headers: config.trusted_headers.clone()
         })
     }
 }
@@ -499,7 +507,6 @@ pub fn read_and_validate_config<B: BuildTimeConfig>(
 ) -> Result<(CageConfig, ValidatedCageBuildConfig), CageConfigError> {
     let cage_config = CageConfig::try_from_filepath(config_path)?;
     let merged_config = args.merge_with_config(&cage_config);
-
     let validated_config: ValidatedCageBuildConfig = merged_config.as_ref().try_into()?;
 
     Ok((cage_config, validated_config))
@@ -550,6 +557,7 @@ mod test {
             trx_logging: true,
             forward_proxy_protocol: false,
             runtime: None,
+            trusted_headers: vec![]
         };
 
         let test_args = ExampleArgs {

--- a/src/config.rs
+++ b/src/config.rs
@@ -339,7 +339,7 @@ impl ValidatedCageBuildConfig {
     }
 
     pub fn trusted_headers(&self) -> &[String] {
-      &self.trusted_headers
+        &self.trusted_headers
     }
 }
 
@@ -461,7 +461,7 @@ impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
             trx_logging_enabled,
             runtime: config.runtime.clone(),
             forward_proxy_protocol: config.forward_proxy_protocol,
-            trusted_headers: config.trusted_headers.clone()
+            trusted_headers: config.trusted_headers.clone(),
         })
     }
 }
@@ -557,7 +557,7 @@ mod test {
             trx_logging: true,
             forward_proxy_protocol: false,
             runtime: None,
-            trusted_headers: vec![]
+            trusted_headers: vec![],
         };
 
         let test_args = ExampleArgs {


### PR DESCRIPTION
# Why
Introducing new config which will allow customers to configure a list of trusted headers which we can present unredacted in transaction logs

# How
- Add trusted headers flag to build and init commands
- Added support to cage config struct
