### PR TITLE
Remove unnecessary error messages

### DIFF
--- a/src/cli/delete.rs
+++ b/src/cli/delete.rs
@@ -62,7 +62,7 @@ pub async fn run(delete_args: DeleteArgs) -> exitcode::ExitCode {
             }
         }
         Err(e) => {
-            log::info!("{}", e);
+            log::error!("{}", e);
             return e.exitcode();
         }
     };

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -31,7 +31,7 @@ pub async fn run(restart_args: RestartArgs) -> i32 {
     {
         Ok(_) => println!("Cage restart started"),
         Err(e) => {
-            log::info!("{}", e);
+            log::error!("{}", e);
             return e.exitcode();
         }
     };

--- a/src/delete/mod.rs
+++ b/src/delete/mod.rs
@@ -34,7 +34,6 @@ pub async fn delete_cage(
     let deleted_cage = match cage_api.delete_cage(&cage_uuid).await {
         Ok(cage_ref) => cage_ref,
         Err(e) => {
-            log::error!("Error initiating cage deletion — {:?}", e);
             return Err(DeleteError::ApiError(e));
         }
     };

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -169,10 +169,7 @@ async fn watch_deployment(
                 };
                 Ok(status_report)
             }
-            Err(e) => {
-                log::error!("Unable to retrieve deployment status. Error: {:?}", e);
-                Ok(StatusReport::Failed)
-            }
+            Err(e) => Ok(StatusReport::Failed),
         }
     }
 

--- a/src/restart/mod.rs
+++ b/src/restart/mod.rs
@@ -56,7 +56,6 @@ pub async fn restart_cage(
     match cage_api.restart_cage(&cage_uuid).await {
         Ok(_) => Ok(()),
         Err(e) => {
-            log::error!("Error initiating cage deletion — {:?}", e);
             return Err(RestartError::ApiError(e));
         }
     }


### PR DESCRIPTION
# Why

Better error messaging was added in #25 but some commands are still printing their own error messages

<img width="1735" alt="image" src="https://github.com/evervault/cage-cli/assets/39464373/47bea5c3-1dff-42e4-9083-1d4a605a8588">

# How

Remove unnecessary error messages
