### PR TITLE
markd/add progress polling to cage restarts

### DIFF
--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -219,12 +219,13 @@ impl CagesClient {
             .await
     }
 
-    pub async fn restart_cage(&self, cage_uuid: &str) -> ApiResult<()> {
+    pub async fn restart_cage(&self, cage_uuid: &str) -> ApiResult<CageDeployment> {
         let patch_cage_url = format!("{}/{}", self.base_url(), cage_uuid);
         self.patch(&patch_cage_url)
             .send()
             .await
-            .handle_no_op_response()
+            .handle_json_response()
+            .await
     }
 }
 
@@ -476,6 +477,14 @@ pub struct CageDeployment {
 impl CageDeployment {
     pub fn is_finished(&self) -> bool {
         self.completed_at.is_some()
+    }
+
+    pub fn cage_uuid(&self) -> &str {
+        &self.cage_uuid
+    }
+
+    pub fn uuid(&self) -> &str {
+        &self.uuid
     }
 }
 

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -46,7 +46,7 @@ pub async fn run(restart_args: RestartArgs) -> i32 {
     };
 
     if restart_args.background {
-        println!("Cage restarted started. You can observe it's progess in the Cages Dashboard");
+        println!("Cage restarting. You can observe the restart progress in the Cages Dashboard");
         return exitcode::OK;
     }
 

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -1,4 +1,11 @@
-use crate::{common::CliError, get_api_key, restart::restart_cage};
+use crate::{
+    api::{cage::CagesClient, AuthMode},
+    common::CliError,
+    deploy::{timed_operation, watch_deployment, DEPLOY_WATCH_TIMEOUT_SECONDS},
+    get_api_key,
+    progress::get_tracker,
+    restart::restart_cage,
+};
 use clap::Parser;
 
 /// Restart the Cage deployment
@@ -21,20 +28,44 @@ pub struct RestartArgs {
 pub async fn run(restart_args: RestartArgs) -> i32 {
     let api_key = get_api_key!();
 
-    match restart_cage(
+    let cage_api = CagesClient::new(AuthMode::ApiKey(api_key.to_string()));
+
+    let new_deployment = match restart_cage(
         restart_args.config.as_str(),
         restart_args.cage_uuid.as_deref(),
-        api_key.as_str(),
+        &cage_api,
         restart_args.background,
     )
     .await
     {
-        Ok(_) => println!("Cage restart started"),
+        Ok(depl) => depl,
         Err(e) => {
             log::error!("{}", e);
             return e.exitcode();
         }
     };
 
-    exitcode::OK
+    let progress_bar = get_tracker(
+        "Deploying Cage into a Trusted Execution Environment...",
+        None,
+    );
+
+    match timed_operation(
+        "Cage Deployment",
+        DEPLOY_WATCH_TIMEOUT_SECONDS,
+        watch_deployment(
+            cage_api,
+            new_deployment.cage_uuid(),
+            new_deployment.uuid(),
+            progress_bar,
+        ),
+    )
+    .await
+    {
+        Ok(_) => exitcode::OK,
+        Err(e) => {
+            log::error!("{}", e);
+            e.exitcode()
+        }
+    }
 }

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -50,6 +50,11 @@ pub async fn run(restart_args: RestartArgs) -> i32 {
         None,
     );
 
+    if restart_args.background {
+        println!("Cage restarted started. You can observe it's progess in the Cages Dashboard");
+        return exitcode::OK;
+    }
+
     match timed_operation(
         "Cage Deployment",
         DEPLOY_WATCH_TIMEOUT_SECONDS,

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -45,15 +45,15 @@ pub async fn run(restart_args: RestartArgs) -> i32 {
         }
     };
 
-    let progress_bar = get_tracker(
-        "Deploying Cage into a Trusted Execution Environment...",
-        None,
-    );
-
     if restart_args.background {
         println!("Cage restarted started. You can observe it's progess in the Cages Dashboard");
         return exitcode::OK;
     }
+
+    let progress_bar = get_tracker(
+        "Deploying Cage into a Trusted Execution Environment...",
+        None,
+    );
 
     match timed_operation(
         "Cage Deployment",

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -19,7 +19,7 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 const ENCLAVE_ZIP_FILENAME: &str = "enclave.zip";
-const DEPLOY_WATCH_TIMEOUT_SECONDS: u64 = 600; //10 minutes
+pub const DEPLOY_WATCH_TIMEOUT_SECONDS: u64 = 600; //10 minutes
 
 pub async fn deploy_eif(
     validated_config: &ValidatedCageBuildConfig,
@@ -137,7 +137,7 @@ async fn watch_build(
     .await;
 }
 
-async fn watch_deployment(
+pub async fn watch_deployment(
     cage_api: CagesClient,
     cage_uuid: &str,
     deployment_uuid: &str,
@@ -169,7 +169,7 @@ async fn watch_deployment(
                 };
                 Ok(status_report)
             }
-            Err(e) => Ok(StatusReport::Failed),
+            Err(_) => Ok(StatusReport::Failed),
         }
     }
 

--- a/src/restart/mod.rs
+++ b/src/restart/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{self, AuthMode},
+    api::cage::{CageDeployment, CagesClient},
     common::CliError,
     config::{CageConfig, CageConfigError},
 };
@@ -42,21 +42,16 @@ fn resolve_cage_uuid(
 pub async fn restart_cage(
     config: &str,
     cage_uuid: Option<&str>,
-    api_key: &str,
-    _background: bool, // TODO(Mark): implement cage restart polling
-) -> Result<(), RestartError> {
+    cage_api: &CagesClient,
+    _background: bool,
+) -> Result<CageDeployment, RestartError> {
     let maybe_cage_uuid = resolve_cage_uuid(cage_uuid, config)?;
     let cage_uuid = match maybe_cage_uuid {
         Some(given_cage_uuid) => given_cage_uuid,
         _ => return Err(RestartError::MissingUuid),
     };
 
-    let cage_api = api::cage::CagesClient::new(AuthMode::ApiKey(api_key.to_string()));
+    println!("Restarting cage {}...", cage_uuid);
 
-    match cage_api.restart_cage(&cage_uuid).await {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            return Err(RestartError::ApiError(e));
-        }
-    }
+    Ok(cage_api.restart_cage(&cage_uuid).await?)
 }


### PR DESCRIPTION
# Why
Provide observability into Cage restarts

closes SPE-789

# How
Reuse polling logic from deploy command
