### PR TITLE
Bump deployment timeout

### DIFF
--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -19,7 +19,7 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 const ENCLAVE_ZIP_FILENAME: &str = "enclave.zip";
-pub const DEPLOY_WATCH_TIMEOUT_SECONDS: u64 = 600; //10 minutes
+pub const DEPLOY_WATCH_TIMEOUT_SECONDS: u64 = 900; //15 minutes
 
 pub async fn deploy_eif(
     validated_config: &ValidatedCageBuildConfig,


### PR DESCRIPTION
# Why
Cage deployments often take longer than 10 minutes which means CI runs can fail even when deployments are ultimately successful

# How
Bump timeout to 15 mins
