### PR TITLE
Repro builds for multistep builds

### DIFF
--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -26,6 +26,8 @@ pub enum BuildError {
     EnclaveConversionError(String),
     #[error(transparent)]
     EnclaveError(#[from] EnclaveError),
+    #[error(transparent)]
+    Utf8Error(#[from] std::str::Utf8Error),
 }
 
 impl CliError for BuildError {
@@ -37,7 +39,9 @@ impl CliError for BuildError {
             Self::FailedToAccessOutputDir(_) | Self::FailedToWriteCageDockerfile(_) => {
                 exitcode::IOERR
             }
-            Self::DockerError(_) | Self::DockerBuildError(_) => exitcode::SOFTWARE,
+            Self::DockerError(_) | Self::DockerBuildError(_) | Self::Utf8Error(_) => {
+                exitcode::SOFTWARE
+            }
             Self::EnclaveConversionError(_) => exitcode::SOFTWARE,
             Self::EnclaveError(e) => e.exitcode(),
         }


### PR DESCRIPTION
# Why
Once of the repro build workarounds is to squash the image using `COPY --from=0 / /`. This broke multistep step builds

# How
- Check if there's more than one FROM directive in the Dockerfile
- Check if the last FROM has an alias, if it does use it
- If not add an alias called `lastlayer`
- Use alias in the final squashing stage
