### PR TITLE
fix: only remove env directives when performing reproducible builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +792,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "thiserror",
@@ -2285,6 +2299,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ regex = "1.8.1"
 
 [dev-dependencies]
 tokio-test = "0.4.2"
+serial_test = "2.0.0"
 
 [target.'cfg(unix)'.dependencies]
 aws-nitro-enclaves-nsm-api = { version = "0.2.1" }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -281,6 +281,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_reproducible_cage_builds_with_pinned_version() {
         let current_dir = std::env::current_dir().unwrap();
         let (build_output, output_path) = test_utils::build_test_cage(


### PR DESCRIPTION
# Why
Environment variables are being stripped from docker files during the build phase, and added to the user start script. This breaks dockerfiles which are setting env vars for their own builds.

# How
Add check in CLI to only remove environment variables when attempting a reproducible build
