### PR TITLE
Handle cert lock request on new cages

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -74,7 +74,7 @@ pub async fn build_enclave_image_file(
     };
 
     if let Some(output_path) = output_path.path().as_os_str().to_str() {
-      log::debug!("Building Nitro CLI image... {output_path}");
+        log::debug!("Building Nitro CLI image... {output_path}");
     }
 
     enclave::build_nitro_cli_image(output_path.path(), Some(&signing_info), verbose)?;

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -73,10 +73,9 @@ pub async fn build_enclave_image_file(
         }
     };
 
-    log::debug!(
-        "Building Nitro CLI image... {}",
-        output_path.path().as_os_str().to_str().unwrap()
-    );
+    if let Some(output_path) = output_path.path().as_os_str().to_str() {
+      log::debug!("Building Nitro CLI image... {output_path}");
+    }
 
     enclave::build_nitro_cli_image(output_path.path(), Some(&signing_info), verbose)?;
     log::info!("Converting docker image to EIF...");

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -10,7 +10,7 @@ use crate::enclave;
 
 use serde_json::json;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tokio::fs::File;
 use tokio::io::AsyncRead;
 
@@ -19,6 +19,7 @@ const INSTALLER_DIRECTORY: &str = "/opt/evervault";
 const USER_ENTRYPOINT_SERVICE_PATH: &str = "/etc/service/user-entrypoint";
 const DATA_PLANE_SERVICE_PATH: &str = "/etc/service/data-plane";
 
+#[allow(clippy::too_many_arguments)]
 pub async fn build_enclave_image_file(
     cage_config: &ValidatedCageBuildConfig,
     context_path: &str,
@@ -84,6 +85,7 @@ pub async fn build_enclave_image_file(
         .map_err(|e| e.into())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn build_from_scratch(
     cage_config: &ValidatedCageBuildConfig,
     context_path: &Path,
@@ -91,7 +93,7 @@ pub async fn build_from_scratch(
     docker_build_args: Option<Vec<&str>>,
     data_plane_version: String,
     installer_version: String,
-    output_path: &PathBuf,
+    output_path: &Path,
     timestamp: String,
     reproducible: bool,
 ) -> Result<(), BuildError> {
@@ -121,7 +123,7 @@ pub async fn build_from_scratch(
     .await?;
 
     // write new dockerfile to fs
-    let user_dockerfile_path = output_path.as_path().join(EV_USER_DOCKERFILE_PATH);
+    let user_dockerfile_path = output_path.join(EV_USER_DOCKERFILE_PATH);
 
     let mut ev_user_dockerfile = std::fs::File::create(&user_dockerfile_path)
         .map_err(BuildError::FailedToWriteCageDockerfile)?;
@@ -270,7 +272,7 @@ async fn process_dockerfile<R: AsyncRead + std::marker::Unpin>(
 
     let dataplane_env = format!(
         "echo {} > /etc/dataplane-config.json",
-        dataplane_info.to_string().replace("\"", "\\\"")
+        dataplane_info.to_string().replace('"', "\\\"")
     );
 
     let injected_directives = vec![
@@ -386,7 +388,7 @@ pub fn build_user_service(
     };
     let exec_cmd = format!("exec {}", entrypoint);
 
-    let env_cmd = if user_env_vars.len() > 0 {
+    let env_cmd = if !user_env_vars.is_empty() {
         format!(
             "export {}",
             user_env_vars

--- a/src/cert/error.rs
+++ b/src/cert/error.rs
@@ -30,7 +30,7 @@ pub enum CertError {
     #[error("Failed to parse timestamp")]
     TimstampParseError(#[from] chrono::ParseError),
     #[error("No certs found for the current Cage.")]
-    NoCertsFound
+    NoCertsFound,
 }
 
 impl CliError for CertError {
@@ -48,7 +48,7 @@ impl CliError for CertError {
             | Self::CertPathDoesNotExist(_)
             | Self::TimstampParseError(_) => exitcode::DATAERR,
             Self::ApiError(inner) => inner.exitcode(),
-            Self::NoCertsFound => exitcode::USAGE
+            Self::NoCertsFound => exitcode::USAGE,
         }
     }
 }

--- a/src/cert/error.rs
+++ b/src/cert/error.rs
@@ -29,6 +29,8 @@ pub enum CertError {
     HashError(String),
     #[error("Failed to parse timestamp")]
     TimstampParseError(#[from] chrono::ParseError),
+    #[error("No certs found for the current Cage.")]
+    NoCertsFound
 }
 
 impl CliError for CertError {
@@ -46,6 +48,7 @@ impl CliError for CertError {
             | Self::CertPathDoesNotExist(_)
             | Self::TimstampParseError(_) => exitcode::DATAERR,
             Self::ApiError(inner) => inner.exitcode(),
+            Self::NoCertsFound => exitcode::USAGE
         }
     }
 }

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -220,7 +220,7 @@ pub async fn lock_cage_to_certs(
     let certs_for_select = get_certs_for_selection(cage_api.clone(), cage_uuid).await?;
 
     if certs_for_select.is_empty() {
-        log::error!("No certs found for {cage_name}. You must upload a cert using the `ev cert upload` command or perform a deployment before you can create a cert lock.");
+        log::error!("No certs found for the current app. You must upload a cert using the `ev cert upload` command or deployment a Cage before you can create a cert lock.");
         return Err(CertError::NoCertsFound);
     }
 

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -219,6 +219,11 @@ pub async fn lock_cage_to_certs(
 
     let certs_for_select = get_certs_for_selection(cage_api.clone(), cage_uuid).await?;
 
+    if certs_for_select.is_empty() {
+      log::error!("No certs found for {cage_name}. You must upload a cert using the `ev cert upload` command or perform a deployment before you can create a cert lock.");
+      return Ok(());
+    }
+
     let sorted_certs_for_select = sort_certs_by_expiry(certs_for_select)?;
 
     let chosen: Vec<usize> = MultiSelect::new()
@@ -277,7 +282,7 @@ pub async fn lock_cage_to_certs(
         .update_cage_locked_signing_certs(cage_uuid, payload)
         .await
     {
-        log::error!("Error locking cage to certs — {:?}", e);
+        log::error!("Error locking Cage to certs - {e}");
         return Err(CertError::ApiError(e));
     };
 

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -114,7 +114,7 @@ pub async fn upload_new_cert_ref(
 }
 
 fn format_cert_for_multi_select(cert: &CageSigningCert) -> String {
-    let name = cert.name().unwrap_or_else(|| "".to_string());
+    let name = cert.name().unwrap_or_default();
     let cert_hash = cert.cert_hash();
     let not_after = cert
         .not_after()
@@ -241,12 +241,11 @@ pub async fn lock_cage_to_certs(
 
     let chosen_cert_uuids = chosen
         .iter()
-        .map(|index| {
+        .filter_map(|index| {
             sorted_certs_for_select
                 .get(*index)
-                .and_then(|cert| Some(cert.cert.uuid().to_string()))
+                .map(|cert| cert.cert.uuid().to_string())
         })
-        .flatten()
         .collect::<Vec<String>>();
 
     let payload = UpdateLockedCageSigningCertRequest::new(chosen_cert_uuids.clone());

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -221,7 +221,7 @@ pub async fn lock_cage_to_certs(
 
     if certs_for_select.is_empty() {
         log::error!("No certs found for {cage_name}. You must upload a cert using the `ev cert upload` command or perform a deployment before you can create a cert lock.");
-        return Ok(());
+        return Err(CertError::NoCertsFound);
     }
 
     let sorted_certs_for_select = sort_certs_by_expiry(certs_for_select)?;

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -220,8 +220,8 @@ pub async fn lock_cage_to_certs(
     let certs_for_select = get_certs_for_selection(cage_api.clone(), cage_uuid).await?;
 
     if certs_for_select.is_empty() {
-      log::error!("No certs found for {cage_name}. You must upload a cert using the `ev cert upload` command or perform a deployment before you can create a cert lock.");
-      return Ok(());
+        log::error!("No certs found for {cage_name}. You must upload a cert using the `ev cert upload` command or perform a deployment before you can create a cert lock.");
+        return Ok(());
     }
 
     let sorted_certs_for_select = sort_certs_by_expiry(certs_for_select)?;

--- a/src/cli/cert.rs
+++ b/src/cli/cert.rs
@@ -165,7 +165,7 @@ pub async fn run(cert_args: CertArgs) -> exitcode::ExitCode {
             };
 
             if let Err(e) = cert::lock_cage_to_certs(&api_key, &cage_uuid, &cage_name).await {
-              return e.exitcode();
+                return e.exitcode();
             }
         }
     }

--- a/src/cli/cert.rs
+++ b/src/cli/cert.rs
@@ -164,9 +164,9 @@ pub async fn run(cert_args: CertArgs) -> exitcode::ExitCode {
                 }
             };
 
-            cert::lock_cage_to_certs(&api_key, &cage_uuid, &cage_name)
-                .await
-                .unwrap();
+            if let Err(e) = cert::lock_cage_to_certs(&api_key, &cage_uuid, &cage_name).await {
+              return e.exitcode();
+            }
         }
     }
 

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -172,6 +172,7 @@ pub async fn run(deploy_args: DeployArgs) -> exitcode::ExitCode {
     exitcode::OK
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn resolve_eif(
     validated_config: &ValidatedCageBuildConfig,
     context_path: &str,

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -111,7 +111,7 @@ impl std::convert::From<InitArgs> for CageConfig {
             trx_logging: !val.trx_logging_disabled,
             runtime: None,
             forward_proxy_protocol: val.forward_proxy_protocol,
-            trusted_headers: convert_comma_list(val.trusted_headers).unwrap_or_else(|| vec![]),
+            trusted_headers: convert_comma_list(val.trusted_headers).unwrap_or_default(),
         }
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -78,7 +78,9 @@ pub fn update_cage_config_with_eif_measurements(
     runtime_info: Option<RuntimeVersions>,
 ) {
     cage_config.set_attestation(eif_measurements);
-    runtime_info.map(|info| cage_config.set_runtime_info(info));
+    if let Some(info) = runtime_info {
+        cage_config.set_runtime_info(info);
+    }
 
     if let Ok(serialized_config) = toml::ser::to_vec(&cage_config) {
         match std::fs::write(config_path, serialized_config) {

--- a/src/docker/command.rs
+++ b/src/docker/command.rs
@@ -1,7 +1,7 @@
 use super::error::CommandError;
 use git2::Repository;
 use std::ffi::OsStr;
-use std::path::PathBuf;
+use std::path::Path;
 use std::process::{Command, ExitStatus, Output, Stdio};
 
 pub struct CommandConfig {
@@ -27,7 +27,7 @@ impl CommandConfig {
 }
 
 pub fn load_image_into_local_docker_registry(
-    image_archive: &PathBuf,
+    image_archive: &Path,
     verbose: bool,
 ) -> Result<ExitStatus, CommandError> {
     let command_config = CommandConfig::new(verbose);
@@ -62,7 +62,7 @@ fn docker_buildkit_enabled() -> Result<bool, CommandError> {
         .as_str();
 
     let min_version = Version::from("0.10.0").ok_or(CommandError::SemverParseError)?;
-    let user_version = Version::from(&semver_match).ok_or(CommandError::SemverParseError)?;
+    let user_version = Version::from(semver_match).ok_or(CommandError::SemverParseError)?;
     Ok(user_version >= min_version)
 }
 


### PR DESCRIPTION
# Why
Cert lock command currently panics when used on a new cage as no certs are returned from the API. This is then passed into the multi-select from dialoguer which errors which we then unwrap.

# How
- Update logic to check if no certs were returned. If that is the case, we then log instructions to upload/deploy which will create certs.
- Remove other low hanging unwraps
- Resolve all of clippy's lints
