### PR TITLE
Add healthcheck support to cage config

### DIFF
--- a/.github/workflows/lint-and-test-cli.yml
+++ b/.github/workflows/lint-and-test-cli.yml
@@ -16,7 +16,7 @@ jobs:
           SKIP_LOGIN: true
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-09-13
           override: true
           components: rustfmt, clippy
       - name: Compile project

--- a/.github/workflows/lint-and-test-cli.yml
+++ b/.github/workflows/lint-and-test-cli.yml
@@ -20,7 +20,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Compile project
-        run: cargo build --all-features -p ev-cage
+        run: cargo build --all-features -p ev-cage -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/lint-and-test-cli.yml
+++ b/.github/workflows/lint-and-test-cli.yml
@@ -20,7 +20,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Compile project
-        run: cargo build --all-features -p ev-cage -Z registry-auth
+        run: cargo build --all-features -p ev-cage
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2023-09-13
           override: true
           target: ${{ env.LINUX_TARGET }}
 
@@ -86,7 +86,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-09-13
           target: ${{ env.MACOS_TARGET }}
           override: true
       
@@ -135,7 +135,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-09-13
           target: ${{ env.WINDOWS_TARGET }}
           override: true
 

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           mkdir ${{ env.BIN_DIR }}
           mkdir ${{ env.RELEASE_DIR }}
-          cross build --release --target ${{ env.LINUX_TARGET }}
+          cross build --release --target ${{ env.LINUX_TARGET }} -Z registry-auth
           mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
           7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
         env:
@@ -98,7 +98,7 @@ jobs:
       - name: Build CLI MacOs Target
         run: |
           cargo install cross
-          cross build --release --target ${{ env.MACOS_TARGET }}
+          cross build --release --target ${{ env.MACOS_TARGET }} -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
@@ -149,7 +149,7 @@ jobs:
             shared-key: "windows-cross-builds"
 
       - name: Fetch dependencies
-        run: cargo fetch
+        run: cargo fetch -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
@@ -157,7 +157,7 @@ jobs:
       - name: Build CLI for Windows
         run: |
           cargo install cross
-          cross build --release --target ${{ env.WINDOWS_TARGET }}
+          cross build --release --target ${{ env.WINDOWS_TARGET }} -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           mkdir ${{ env.BIN_DIR }}
           mkdir ${{ env.RELEASE_DIR }}
-          cross build --release --target ${{ env.LINUX_TARGET }} -Z registry-auth
+          cross build --release --target ${{ env.LINUX_TARGET }}
           mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
           7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
         env:
@@ -98,7 +98,7 @@ jobs:
       - name: Build CLI MacOs Target
         run: |
           cargo install cross
-          cross build --release --target ${{ env.MACOS_TARGET }} -Z registry-auth
+          cross build --release --target ${{ env.MACOS_TARGET }}
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
@@ -149,7 +149,7 @@ jobs:
             shared-key: "windows-cross-builds"
 
       - name: Fetch dependencies
-        run: cargo fetch -Z registry-auth
+        run: cargo fetch
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
@@ -157,7 +157,7 @@ jobs:
       - name: Build CLI for Windows
         run: |
           cargo install cross
-          cross build --release --target ${{ env.WINDOWS_TARGET }} -Z registry-auth
+          cross build --release --target ${{ env.WINDOWS_TARGET }}
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,11 +1207,12 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.3"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
 dependencies = [
  "console",
+ "instant",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
@@ -1776,9 +1777,9 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.19"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "ppv-lite86"

--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -779,6 +779,7 @@ mod test {
             build_status: BuildStatus::Ready,
             failure_reason: None,
             started_at: None,
+            healthcheck: None
         }
     }
 

--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -252,6 +252,7 @@ pub struct CreateCageDeploymentIntentRequest {
     not_before: String,
     not_after: String,
     metadata: VersionMetadata,
+    healthcheck: Option<String>
 }
 
 impl CreateCageDeploymentIntentRequest {
@@ -263,6 +264,7 @@ impl CreateCageDeploymentIntentRequest {
         installer_version: String,
         git_timestamp: String,
         git_hash: String,
+        healthcheck: Option<String>
     ) -> Self {
         Self {
             pcrs: pcrs.clone(),
@@ -279,6 +281,7 @@ impl CreateCageDeploymentIntentRequest {
                 data_plane_version,
                 git_timestamp,
             },
+            healthcheck
         }
     }
 }
@@ -508,6 +511,7 @@ pub struct CageVersion {
     build_status: BuildStatus,
     failure_reason: Option<String>,
     started_at: Option<String>,
+    healthcheck: Option<String>
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd)]

--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -252,7 +252,7 @@ pub struct CreateCageDeploymentIntentRequest {
     not_before: String,
     not_after: String,
     metadata: VersionMetadata,
-    healthcheck: Option<String>
+    healthcheck: Option<String>,
 }
 
 impl CreateCageDeploymentIntentRequest {
@@ -264,7 +264,7 @@ impl CreateCageDeploymentIntentRequest {
         installer_version: String,
         git_timestamp: String,
         git_hash: String,
-        healthcheck: Option<String>
+        healthcheck: Option<String>,
     ) -> Self {
         Self {
             pcrs: pcrs.clone(),
@@ -281,7 +281,7 @@ impl CreateCageDeploymentIntentRequest {
                 data_plane_version,
                 git_timestamp,
             },
-            healthcheck
+            healthcheck,
         }
     }
 }
@@ -511,7 +511,7 @@ pub struct CageVersion {
     build_status: BuildStatus,
     failure_reason: Option<String>,
     started_at: Option<String>,
-    healthcheck: Option<String>
+    healthcheck: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd)]
@@ -779,7 +779,7 @@ mod test {
             build_status: BuildStatus::Ready,
             failure_reason: None,
             started_at: None,
-            healthcheck: None
+            healthcheck: None,
         }
     }
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -471,7 +471,7 @@ mod test {
             runtime: None,
             forward_proxy_protocol: false,
             trusted_headers: vec!["X-Evervault-*".to_string()],
-            healthcheck: None
+            healthcheck: None,
         }
     }
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -471,6 +471,7 @@ mod test {
             runtime: None,
             forward_proxy_protocol: false,
             trusted_headers: vec!["X-Evervault-*".to_string()],
+            healthcheck: None
         }
     }
 

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -59,7 +59,7 @@ pub struct DeployArgs {
 
     /// Healthcheck path exposed by your service
     #[clap(long = "healthcheck")]
-    pub healthcheck: Option<String>
+    pub healthcheck: Option<String>,
 }
 
 impl BuildTimeConfig for DeployArgs {

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -56,6 +56,10 @@ pub struct DeployArgs {
     /// Deterministic builds
     #[clap(long = "reproducible")]
     pub reproducible: bool,
+
+    /// Healthcheck path exposed by your service
+    #[clap(long = "healthcheck")]
+    pub healthcheck: Option<String>
 }
 
 impl BuildTimeConfig for DeployArgs {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -79,6 +79,10 @@ pub struct InitArgs {
     /// Trusted headers sent into the Cage will be persisted without redaction in the Cage's transaction logs
     #[clap(long = "trusted_headers")]
     pub trusted_headers: Option<String>,
+
+    /// The healthcheck endpoint exposed by your service
+    #[clap(long = "healthcheck")]
+    pub healthcheck: Option<String>,
 }
 
 impl std::convert::From<InitArgs> for CageConfig {
@@ -112,6 +116,7 @@ impl std::convert::From<InitArgs> for CageConfig {
             runtime: None,
             forward_proxy_protocol: val.forward_proxy_protocol,
             trusted_headers: convert_comma_list(val.trusted_headers).unwrap_or_default(),
+            healthcheck: val.healthcheck
         }
     }
 }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -218,6 +218,7 @@ mod init_tests {
             egress_destinations: Some("evervault.com".to_string()),
             forward_proxy_protocol: false,
             trusted_headers: Some("X-Evervault-*".to_string()),
+            healthcheck: None,
         };
         init_local_config(init_args, sample_cage).await;
         let config_path = output_dir.path().join("cage.toml");

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -116,7 +116,7 @@ impl std::convert::From<InitArgs> for CageConfig {
             runtime: None,
             forward_proxy_protocol: val.forward_proxy_protocol,
             trusted_headers: convert_comma_list(val.trusted_headers).unwrap_or_default(),
-            healthcheck: val.healthcheck
+            healthcheck: val.healthcheck,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,6 +238,8 @@ pub struct CageConfig {
     pub forward_proxy_protocol: bool,
     #[serde(default)]
     pub trusted_headers: Vec<String>,
+    #[serde(default)]
+    pub healthcheck: Option<String>,
     // Table configs
     pub egress: EgressSettings,
     pub signing: Option<SigningInfo>,
@@ -277,6 +279,7 @@ pub struct ValidatedCageBuildConfig {
     pub runtime: Option<RuntimeVersions>,
     pub forward_proxy_protocol: bool,
     pub trusted_headers: Vec<String>,
+    pub healthcheck: Option<String>
 }
 
 impl ValidatedCageBuildConfig {
@@ -340,6 +343,10 @@ impl ValidatedCageBuildConfig {
 
     pub fn trusted_headers(&self) -> &[String] {
         &self.trusted_headers
+    }
+
+    pub fn healthcheck(&self) -> Option<&str> {
+      self.healthcheck.as_deref()
     }
 }
 
@@ -462,6 +469,7 @@ impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
             runtime: config.runtime.clone(),
             forward_proxy_protocol: config.forward_proxy_protocol,
             trusted_headers: config.trusted_headers.clone(),
+            healthcheck: config.healthcheck.clone()
         })
     }
 }
@@ -558,6 +566,7 @@ mod test {
             forward_proxy_protocol: false,
             runtime: None,
             trusted_headers: vec![],
+            healthcheck: Some("/health".to_string())
         };
 
         let test_args = ExampleArgs {

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,7 +279,7 @@ pub struct ValidatedCageBuildConfig {
     pub runtime: Option<RuntimeVersions>,
     pub forward_proxy_protocol: bool,
     pub trusted_headers: Vec<String>,
-    pub healthcheck: Option<String>
+    pub healthcheck: Option<String>,
 }
 
 impl ValidatedCageBuildConfig {
@@ -346,7 +346,7 @@ impl ValidatedCageBuildConfig {
     }
 
     pub fn healthcheck(&self) -> Option<&str> {
-      self.healthcheck.as_deref()
+        self.healthcheck.as_deref()
     }
 }
 
@@ -469,7 +469,7 @@ impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
             runtime: config.runtime.clone(),
             forward_proxy_protocol: config.forward_proxy_protocol,
             trusted_headers: config.trusted_headers.clone(),
-            healthcheck: config.healthcheck.clone()
+            healthcheck: config.healthcheck.clone(),
         })
     }
 }
@@ -566,7 +566,7 @@ mod test {
             forward_proxy_protocol: false,
             runtime: None,
             trusted_headers: vec![],
-            healthcheck: Some("/health".to_string())
+            healthcheck: Some("/health".to_string()),
         };
 
         let test_args = ExampleArgs {

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -48,7 +48,7 @@ pub async fn deploy_eif(
         installer_version,
         get_source_date_epoch(),
         get_git_hash(),
-        validated_config.healthcheck().map(String::from)
+        validated_config.healthcheck().map(String::from),
     );
 
     let deployment_intent = cage_api

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -48,6 +48,7 @@ pub async fn deploy_eif(
         installer_version,
         get_source_date_epoch(),
         get_git_hash(),
+        validated_config.healthcheck().map(String::from)
     );
 
     let deployment_intent = cage_api


### PR DESCRIPTION
# Why
Adding support for custom healthcheck endpoints within Cages to be evaluated within an Enclave

# How
Add healthcheck parameter to the Cage init command, the toml struct, and the create deployment request type

This will allow custom healthchecks to be specified during Cage create:
```sh
ev-cage init --name my-sample-cage --healthcheck /health
```
