### PR TITLE
Add healthcheck to data plane config file

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -270,6 +270,10 @@ async fn process_dockerfile<R: AsyncRead + std::marker::Unpin>(
         dataplane_info["trusted_headers"] = json!(build_config.trusted_headers());
     }
 
+    if let Some(healthcheck) = build_config.healthcheck.as_deref() {
+      dataplane_info["healthcheck"] = json!(healthcheck);
+    }
+
     let dataplane_env = format!(
         "echo {} > /etc/dataplane-config.json",
         dataplane_info.to_string().replace('"', "\\\"")
@@ -768,7 +772,8 @@ EXPOSE 3443
 ENTRYPOINT ["sh", "/hello-script"]"#;
         let mut readable_contents = sample_dockerfile_contents.as_bytes();
 
-        let config = get_config();
+        let mut config: ValidatedCageBuildConfig = get_config();
+        config.healthcheck = Some("/health".into());
 
         let data_plane_version = "0.0.0".to_string();
         let installer_version = "abcdef".to_string();
@@ -790,7 +795,7 @@ USER root
 RUN mkdir -p /opt/evervault
 ADD https://cage-build-assets.evervault.com/installer/abcdef.tar.gz /opt/evervault/runtime-dependencies.tar.gz
 RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
-RUN echo {\"api_key_auth\":true,\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
+RUN echo {\"api_key_auth\":true,\"healthcheck\":\"/health\",\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
 RUN mkdir -p /etc/service/user-entrypoint
 RUN printf "#!/bin/sh\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_CAGE_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
 ADD https://cage-build-assets.evervault.com/runtime/0.0.0/data-plane/egress-disabled/tls-termination-enabled /opt/evervault/data-plane

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -271,7 +271,7 @@ async fn process_dockerfile<R: AsyncRead + std::marker::Unpin>(
     }
 
     if let Some(healthcheck) = build_config.healthcheck.as_deref() {
-      dataplane_info["healthcheck"] = json!(healthcheck);
+        dataplane_info["healthcheck"] = json!(healthcheck);
     }
 
     let dataplane_env = format!(


### PR DESCRIPTION
# Why
A Cage's healthcheck config should be attestable, so it should be included in the data plane config

# How
- Update data plane config file to include healthcheck
- Add tests 