### PR TITLE
[SPE-898] Update cage-cli to handle desired replicas

### DIFF
--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -253,7 +253,7 @@ pub struct CreateCageDeploymentIntentRequest {
     not_after: String,
     metadata: VersionMetadata,
     healthcheck: Option<String>,
-    desired_instances: i32,
+    desired_replicas: i32,
 }
 
 impl CreateCageDeploymentIntentRequest {
@@ -266,7 +266,7 @@ impl CreateCageDeploymentIntentRequest {
         git_timestamp: String,
         git_hash: String,
         healthcheck: Option<String>,
-        desired_instances: i32,
+        desired_replicas: i32,
     ) -> Self {
         Self {
             pcrs: pcrs.clone(),
@@ -284,7 +284,7 @@ impl CreateCageDeploymentIntentRequest {
                 git_timestamp,
             },
             healthcheck,
-            desired_instances,
+            desired_replicas,
         }
     }
 }

--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -253,7 +253,7 @@ pub struct CreateCageDeploymentIntentRequest {
     not_after: String,
     metadata: VersionMetadata,
     healthcheck: Option<String>,
-    desired_replicas: i32,
+    desired_replicas: u32,
 }
 
 impl CreateCageDeploymentIntentRequest {
@@ -266,7 +266,7 @@ impl CreateCageDeploymentIntentRequest {
         git_timestamp: String,
         git_hash: String,
         healthcheck: Option<String>,
-        desired_replicas: i32,
+        desired_replicas: u32,
     ) -> Self {
         Self {
             pcrs: pcrs.clone(),

--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -284,7 +284,7 @@ impl CreateCageDeploymentIntentRequest {
                 git_timestamp,
             },
             healthcheck,
-            desired_instances
+            desired_instances,
         }
     }
 }

--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -253,6 +253,7 @@ pub struct CreateCageDeploymentIntentRequest {
     not_after: String,
     metadata: VersionMetadata,
     healthcheck: Option<String>,
+    desired_instances: i32,
 }
 
 impl CreateCageDeploymentIntentRequest {
@@ -265,6 +266,7 @@ impl CreateCageDeploymentIntentRequest {
         git_timestamp: String,
         git_hash: String,
         healthcheck: Option<String>,
+        desired_instances: i32,
     ) -> Self {
         Self {
             pcrs: pcrs.clone(),
@@ -282,6 +284,7 @@ impl CreateCageDeploymentIntentRequest {
                 git_timestamp,
             },
             healthcheck,
+            desired_instances
         }
     }
 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -462,7 +462,7 @@ mod test {
                 ports: Some(vec!["433".to_string()]),
             },
             scaling: ScalingSettings {
-                desired_instances: 2
+                desired_instances: 2,
             },
             attestation: None,
             signing: ValidatedSigningInfo {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -439,6 +439,7 @@ mod test {
     use super::{process_dockerfile, BuildError};
     use crate::cert::CertValidityPeriod;
     use crate::config::EgressSettings;
+    use crate::config::ScalingSettings;
     use crate::config::ValidatedCageBuildConfig;
     use crate::config::ValidatedSigningInfo;
     use crate::docker;
@@ -459,6 +460,9 @@ mod test {
                 enabled: false,
                 destinations: None,
                 ports: Some(vec!["433".to_string()]),
+            },
+            scaling: ScalingSettings {
+                desired_instances: 2
             },
             attestation: None,
             signing: ValidatedSigningInfo {

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -462,7 +462,7 @@ mod test {
                 ports: Some(vec!["433".to_string()]),
             },
             scaling: ScalingSettings {
-                desired_instances: 2,
+                desired_replicas: 2,
             },
             attestation: None,
             signing: ValidatedSigningInfo {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -85,8 +85,8 @@ pub struct InitArgs {
     pub healthcheck: Option<String>,
 
     /// The desired number of instances for your cage to use. Default is 2.
-    #[clap(long = "desired_instances")]
-    pub desired_instances: Option<i32>,
+    #[clap(long = "desired_replicas")]
+    pub desired_replicas: Option<i32>,
 }
 
 impl std::convert::From<InitArgs> for CageConfig {
@@ -112,7 +112,7 @@ impl std::convert::From<InitArgs> for CageConfig {
                 val.egress,
             ),
             scaling: Some(ScalingSettings {
-                desired_instances: val.desired_instances.unwrap_or(2),
+                desired_replicas: val.desired_replicas.unwrap_or(2),
             }),
             dockerfile: val.dockerfile.unwrap_or_else(default_dockerfile), // need to manually set default dockerfile
             signing: signing_info,
@@ -214,7 +214,7 @@ mod init_tests {
             cage_name: "hello".to_string(),
             debug: false,
             egress: true,
-            desired_instances: Some(2),
+            desired_replicas: Some(2),
             dockerfile: Some("Dockerfile".into()),
             disable_tls_termination: false,
             cert_path: Some("./cert.pem".to_string()),
@@ -250,7 +250,7 @@ destinations = ["evervault.com"]
 ports = ["443"]
 
 [scaling]
-desired_instances = 2
+desired_replicas = 2
 
 [signing]
 certPath = "./cert.pem"

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -86,7 +86,7 @@ pub struct InitArgs {
 
     /// The desired number of instances for your cage to use. Default is 2.
     #[clap(long = "desired_replicas")]
-    pub desired_replicas: Option<i32>,
+    pub desired_replicas: Option<u32>,
 }
 
 impl std::convert::From<InitArgs> for CageConfig {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -2,7 +2,7 @@ use crate::api;
 use crate::api::cage::CreateCageRequest;
 use crate::api::{cage::Cage, AuthMode};
 use crate::common::CliError;
-use crate::config::{default_dockerfile, CageConfig, EgressSettings, SigningInfo, ScalingSettings};
+use crate::config::{default_dockerfile, CageConfig, EgressSettings, ScalingSettings, SigningInfo};
 use crate::get_api_key;
 use clap::{ArgGroup, Parser};
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -2,7 +2,7 @@ use crate::api;
 use crate::api::cage::CreateCageRequest;
 use crate::api::{cage::Cage, AuthMode};
 use crate::common::CliError;
-use crate::config::{default_dockerfile, CageConfig, EgressSettings, SigningInfo};
+use crate::config::{default_dockerfile, CageConfig, EgressSettings, SigningInfo, ScalingSettings};
 use crate::get_api_key;
 use clap::{ArgGroup, Parser};
 
@@ -83,6 +83,10 @@ pub struct InitArgs {
     /// The healthcheck endpoint exposed by your service
     #[clap(long = "healthcheck")]
     pub healthcheck: Option<String>,
+
+    /// The desired number of instances for your cage to use. Default is 2.
+    #[clap(long = "desired_instances")]
+    pub desired_instances: Option<i32>,
 }
 
 impl std::convert::From<InitArgs> for CageConfig {
@@ -107,6 +111,9 @@ impl std::convert::From<InitArgs> for CageConfig {
                 convert_comma_list(val.egress_destinations),
                 val.egress,
             ),
+            scaling: Some(ScalingSettings {
+                desired_instances: val.desired_instances.unwrap_or(2),
+            }),
             dockerfile: val.dockerfile.unwrap_or_else(default_dockerfile), // need to manually set default dockerfile
             signing: signing_info,
             attestation: None,
@@ -207,6 +214,7 @@ mod init_tests {
             cage_name: "hello".to_string(),
             debug: false,
             egress: true,
+            desired_instances: Some(2),
             dockerfile: Some("Dockerfile".into()),
             disable_tls_termination: false,
             cert_path: Some("./cert.pem".to_string()),
@@ -240,6 +248,9 @@ trusted_headers = ["X-Evervault-*"]
 enabled = true
 destinations = ["evervault.com"]
 ports = ["443"]
+
+[scaling]
+desired_instances = 2
 
 [signing]
 certPath = "./cert.pem"

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,12 +67,8 @@ impl Default for ScalingSettings {
 }
 
 impl ScalingSettings {
-    pub fn new(
-        desired_instances: i32,
-    ) -> ScalingSettings {
-        ScalingSettings {
-            desired_instances,
-        }
+    pub fn new(desired_instances: i32) -> ScalingSettings {
+        ScalingSettings { desired_instances }
     }
 
     pub fn get_desired_instances(self) -> i32 {
@@ -481,11 +477,8 @@ impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
             (true, false) => Err(CageConfigError::LoggingEnabledWithoutTLSTermination()), // (logging enabled, tls_termination disabled) = config error (Tls termination needed for logging)
             (true, true) => Ok(true), // (logging enabled, tls_termination enabled) = logging enabled
         }?;
-        
-        let scaling_settings = config
-            .scaling
-            .clone()
-            .unwrap_or_default();
+
+        let scaling_settings = config.scaling.clone().unwrap_or_default();
 
         Ok(ValidatedCageBuildConfig {
             cage_uuid,

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@ impl EgressSettings {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ScalingSettings {
-    pub desired_replicas: i32,
+    pub desired_replicas: u32,
 }
 
 impl Default for ScalingSettings {
@@ -67,11 +67,11 @@ impl Default for ScalingSettings {
 }
 
 impl ScalingSettings {
-    pub fn new(desired_replicas: i32) -> ScalingSettings {
+    pub fn new(desired_replicas: u32) -> ScalingSettings {
         ScalingSettings { desired_replicas }
     }
 
-    pub fn get_desired_replicas(self) -> i32 {
+    pub fn get_desired_replicas(self) -> u32 {
         self.desired_replicas
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,33 @@ impl EgressSettings {
     }
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ScalingSettings {
+    pub desired_instances: i32,
+}
+
+impl Default for ScalingSettings {
+    fn default() -> Self {
+        ScalingSettings {
+            desired_instances: 2,
+        }
+    }
+}
+
+impl ScalingSettings {
+    pub fn new(
+        desired_instances: i32,
+    ) -> ScalingSettings {
+        ScalingSettings {
+            desired_instances,
+        }
+    }
+
+    pub fn get_desired_instances(self) -> i32 {
+        self.desired_instances
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SigningInfo {
     #[serde(rename = "certPath")]
@@ -242,6 +269,7 @@ pub struct CageConfig {
     pub healthcheck: Option<String>,
     // Table configs
     pub egress: EgressSettings,
+    pub scaling: Option<ScalingSettings>,
     pub signing: Option<SigningInfo>,
     pub attestation: Option<EIFMeasurements>,
     pub runtime: Option<RuntimeVersions>,
@@ -271,6 +299,7 @@ pub struct ValidatedCageBuildConfig {
     pub debug: bool,
     pub dockerfile: String,
     pub egress: EgressSettings,
+    pub scaling: ScalingSettings,
     pub signing: ValidatedSigningInfo,
     pub attestation: Option<EIFMeasurements>,
     pub disable_tls_termination: bool,
@@ -452,6 +481,11 @@ impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
             (true, false) => Err(CageConfigError::LoggingEnabledWithoutTLSTermination()), // (logging enabled, tls_termination disabled) = config error (Tls termination needed for logging)
             (true, true) => Ok(true), // (logging enabled, tls_termination enabled) = logging enabled
         }?;
+        
+        let scaling_settings = config
+            .scaling
+            .clone()
+            .unwrap_or_default();
 
         Ok(ValidatedCageBuildConfig {
             cage_uuid,
@@ -462,6 +496,7 @@ impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
             dockerfile: config.dockerfile.clone(),
             egress: config.egress.clone(),
             signing: signing_info.try_into()?,
+            scaling: scaling_settings,
             attestation: config.attestation.clone(),
             disable_tls_termination: config.disable_tls_termination,
             api_key_auth: config.api_key_auth,
@@ -559,6 +594,9 @@ mod test {
                 destinations: None,
                 ports: Some(vec!["443".to_string()]),
             },
+            scaling: Some(super::ScalingSettings {
+                desired_instances: 2,
+            }),
             signing: None,
             attestation: None,
             api_key_auth: true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,24 +55,24 @@ impl EgressSettings {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ScalingSettings {
-    pub desired_instances: i32,
+    pub desired_replicas: i32,
 }
 
 impl Default for ScalingSettings {
     fn default() -> Self {
         ScalingSettings {
-            desired_instances: 2,
+            desired_replicas: 2,
         }
     }
 }
 
 impl ScalingSettings {
-    pub fn new(desired_instances: i32) -> ScalingSettings {
-        ScalingSettings { desired_instances }
+    pub fn new(desired_replicas: i32) -> ScalingSettings {
+        ScalingSettings { desired_replicas }
     }
 
-    pub fn get_desired_instances(self) -> i32 {
-        self.desired_instances
+    pub fn get_desired_replicas(self) -> i32 {
+        self.desired_replicas
     }
 }
 
@@ -588,7 +588,7 @@ mod test {
                 ports: Some(vec!["443".to_string()]),
             },
             scaling: Some(super::ScalingSettings {
-                desired_instances: 2,
+                desired_replicas: 2,
             }),
             signing: None,
             attestation: None,

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -49,7 +49,7 @@ pub async fn deploy_eif(
         get_source_date_epoch(),
         get_git_hash(),
         validated_config.healthcheck().map(String::from),
-        validated_config.scaling.desired_instances,
+        validated_config.scaling.desired_replicas,
     );
 
     let deployment_intent = cage_api

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -49,6 +49,7 @@ pub async fn deploy_eif(
         get_source_date_epoch(),
         get_git_hash(),
         validated_config.healthcheck().map(String::from),
+        validated_config.scaling.desired_instances
     );
 
     let deployment_intent = cage_api

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -49,7 +49,7 @@ pub async fn deploy_eif(
         get_source_date_epoch(),
         get_git_hash(),
         validated_config.healthcheck().map(String::from),
-        validated_config.scaling.desired_instances
+        validated_config.scaling.desired_instances,
     );
 
     let deployment_intent = cage_api


### PR DESCRIPTION
# Why
Adding scaling config to cage toml so customers can specify the number of instances they want to use.

# How
Added scaling section to cage config. We will expand it later to support autoscaling but for now it just has a single value, desired_replicas.

Note: depends on API been updated to accept desired instances
