### PR TITLE
Update deployment timeout to reflect new upper bound

### DIFF
--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -19,7 +19,7 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 const ENCLAVE_ZIP_FILENAME: &str = "enclave.zip";
-pub const DEPLOY_WATCH_TIMEOUT_SECONDS: u64 = 900; //15 minutes
+pub const DEPLOY_WATCH_TIMEOUT_SECONDS: u64 = 1200; //15 minutes
 
 pub async fn deploy_eif(
     validated_config: &ValidatedCageBuildConfig,


### PR DESCRIPTION
# Why
Upper bound for Cage deployments has been extended to 20 minutes. The current CLI limit will result in clients receiving a timeout incorrectly.

# How
Update limit to 20 minutes.
