### PR TITLE
Add registry auth flag to cross build

### DIFF
--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           mkdir ${{ env.BIN_DIR }}
           mkdir ${{ env.RELEASE_DIR }}
-          cross build --release --target ${{ env.LINUX_TARGET }}
+          cross build --release --target ${{ env.LINUX_TARGET }} -Z registry-auth
           mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
           7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
         env:


### PR DESCRIPTION
# Why
Registry auth flag was removed, but is required to build the CLI on nightly.

# How
Restore the registry auth flag
