### PR TITLE
Update cli release flow to push binaries to major path

### DIFF
--- a/.github/fixtures/code-change-push.test.json
+++ b/.github/fixtures/code-change-push.test.json
@@ -1,0 +1,26 @@
+{
+  "after": "",
+  "base_ref": "",
+  "before": "",
+  "commits": [
+    {
+      "author": "",
+      "committer": "",
+      "distinct": true,
+      "id": "00000001",
+      "message": "Add a feature which undeniably makes it better",
+      "modified": ["src/main.rs"],
+      "timestamp": "2023-10-23T18:11:24.647Z",
+      "tree_id": "",
+      "url": ""
+    }
+  ],
+  "compare": "",
+  "created": "",
+  "deleted": "",
+  "forced": "",
+  "head_commit": null,
+  "pusher": {},
+  "ref": "refs/heads/feat/make-it-better",
+  "repository": {}
+}

--- a/.github/fixtures/release-tag.test.json
+++ b/.github/fixtures/release-tag.test.json
@@ -1,0 +1,14 @@
+{
+  "after": "",
+  "base_ref": "",
+  "before": "",
+  "commits": [],
+  "compare": "",
+  "created": "",
+  "deleted": "",
+  "forced": "",
+  "head_commit": null,
+  "pusher": {},
+  "ref": "refs/tags/v1.0.0",
+  "repository": {}
+}

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -20,13 +20,21 @@ jobs:
   get-version:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.get-version.outputs.version }}
+      full_version: ${{ steps.get-full-version.outputs.full_version }}
     steps:
-      - id: get-version
+      - id: get-full-version
         run: |
           echo "using version tag ${GITHUB_REF:11}"
-          echo ::set-output name=version::${GITHUB_REF:11}
-                
+          echo ::set-output name=full_version::${GITHUB_REF:11}
+
+      - id: get-major-version
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const [ref,tag,version] = context.ref.split('/');
+            return version.split('.')[0];
+          result-encoding: string
+
   compile-ubuntu:
     runs-on: ubuntu-latest
     needs: get-version
@@ -54,7 +62,7 @@ jobs:
 
       - name: Inject Version
         run: |
-          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.version }}
+          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.full_version }}
 
       - name: Build and Compress cli
         run: |
@@ -62,7 +70,7 @@ jobs:
           mkdir ${{ env.RELEASE_DIR }}
           cross build --release --target ${{ env.LINUX_TARGET }} -Z registry-auth
           mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
@@ -82,7 +90,7 @@ jobs:
 
       - name: Inject Version
         run: |
-          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.version }}
+          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.full_version }}
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -114,7 +122,7 @@ jobs:
       - name: Compress binary
         run: |
           mv target/${{env.MACOS_TARGET}}/release/ev-cage ${{ env.BIN_DIR }}/ev-cage
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ${{ env.RELEASE_DIR }}/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ${{ env.RELEASE_DIR }}/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
 
       - name: Upload as artifact
         uses: actions/upload-artifact@v2
@@ -141,7 +149,7 @@ jobs:
 
       - name: Inject Version
         run: |
-          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.version }}
+          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.full_version }}
 
       - name: Download cached dependencies
         uses: Swatinem/rust-cache@v2
@@ -172,7 +180,7 @@ jobs:
         shell: bash
         run: |
           mv target/${{ env.WINDOWS_TARGET }}/release/ev-cage.exe ${{ env.BIN_DIR }}/ev-cage.exe
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
 
       - name: Upload as artifact
         uses: actions/upload-artifact@v2
@@ -191,8 +199,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ needs.get-version.outputs.version }}
-          release_name: ${{ needs.get-version.outputs.version }}
+          tag_name: ${{ needs.get-version.outputs.full_version }}
+          release_name: ${{ needs.get-version.outputs.full_version }}
 
       - name: Download MacOS Artifacts
         uses: actions/download-artifact@v1
@@ -215,9 +223,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_path: ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
           asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_name: ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
 
       - name: Upload MacOS Release
         uses: actions/upload-release-asset@v1
@@ -225,9 +233,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_path: ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
           asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_name: ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
 
       - name: Upload Windows Release
         uses: actions/upload-release-asset@v1
@@ -235,15 +243,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_path: ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
           asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz
+          asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
 
   upload-artifacts-to-s3:
     needs: [ get-version , compile-ubuntu, compile-macos, compile-windows ]
     runs-on: ubuntu-latest
     steps:
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -268,23 +275,23 @@ jobs:
 
       - name: Upload Windows CLI to S3
         run: |
-          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.full_version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
 
       - name: Upload MacOS CLI to S3
         run: |
-          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.full_version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
 
       - name: Upload Ubuntu CLI to S3
         run: |
-          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.full_version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
 
       - uses: actions/checkout@v2
       - name: Update install script in S3
         run: |
-          sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.version }}
-          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/install
+          sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.full_version }}
+          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.full_version}}/install
           aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/install
-          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.version}}/version
+          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.full_version}}/version
           aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/version
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/install"
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/version"

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       full_version: ${{ steps.get-full-version.outputs.full_version }}
+      major_version: ${{ steps.get-major-version.outputs.result }}
     steps:
       - id: get-full-version
         run: |
@@ -275,23 +276,20 @@ jobs:
 
       - name: Upload Windows CLI to S3
         run: |
-          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.full_version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.major_version }}/${{ needs.get-version.outputs.full_version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
 
       - name: Upload MacOS CLI to S3
         run: |
-          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.full_version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.full_version }}/${{ needs.get-version.outputs.full_version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
 
       - name: Upload Ubuntu CLI to S3
         run: |
-          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.full_version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.full_version }}/${{ needs.get-version.outputs.full_version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
 
       - uses: actions/checkout@v2
       - name: Update install script in S3
         run: |
           sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.full_version }}
-          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.full_version}}/install
-          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/install
-          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.full_version}}/version
-          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/version
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/install"
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/version"
+          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.major_version }}/${{needs.get-version.outputs.full_version}}/install
+          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.major_version }}/version
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/*"


### PR DESCRIPTION
# Why
To give us better control over versions, we're starting to push our release artefacts under a major version. The distribution will change from:
```
/cli/version
/cli/install
/cli/x.y.z/platform/ev-cage.tar.gz
```
to:
```
/cli/vX/version
/cli/vX/install
/cli/vX/x.y.z/platform/ev-cage.tar.gz
```

# How
- Add additional step to the release workflow which parses the major version from the parsed tag
- Update artefact paths to include the major version as a prefix
- Add fixtures for testing workflows moving forward. You can test the workflows using [act](https://github.com/nektos/act):
```
act -e ./.github/fixtures/release-tag.test.json -W ./.github/workflows/release-cli-version -s GITHUB_TOKEN
```
Or just test a single job in a workflow:
```
act -e ./.github/fixtures/release-tag.test.json -W ./.github/workflows/release-cli-version -j get-version -s GITHUB_TOKEN
```