### PR TITLE
Warn users about old versions and error on deprecated version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rust-crypto",
+ "semver",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -2466,6 +2467,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ sha2 = "0.9.9"
 git2 = "0.17.1"
 version-compare = "0.1.1"
 regex = "1.8.1"
+semver = "1.0.20"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -104,5 +104,4 @@ impl AssetsClient {
             .handle_json_response::<CLIVersion>()
             .await
     }
-    
 }

--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -1,10 +1,24 @@
 use super::client::{ApiClient, ApiClientError, ApiResult, GenericApiClient, HandleResponse};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct RuntimeVersion {
     data_plane: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CLIVersion {
+    pub latest: String,
+    pub versions: HashMap<String, MajorVersion>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MajorVersion {
+    pub latest: String,
+    #[serde(rename = "deprecationDate")]
+    pub deprecation_date: Option<String>,
 }
 
 pub struct AssetsClient {
@@ -81,4 +95,14 @@ impl AssetsClient {
             .await
             .map(|version| version.trim().to_string())
     }
+
+    pub async fn get_cli_versions(&self) -> ApiResult<CLIVersion> {
+        let data_plane_version = format!("{}/cli/versions", self.base_url());
+        self.get(&data_plane_version)
+            .send()
+            .await
+            .handle_json_response::<CLIVersion>()
+            .await
+    }
+    
 }

--- a/src/cli/attest.rs
+++ b/src/cli/attest.rs
@@ -1,6 +1,7 @@
 use crate::attest::attest_connection_to_cage;
 use crate::config::CageConfig;
 use crate::describe::describe_eif;
+use crate::version::check_version;
 use attestation_doc_validation::attestation_doc::PCRs;
 use attestation_doc_validation::PCRProvider;
 use clap::Parser;
@@ -30,6 +31,11 @@ macro_rules! unwrap_or_exit_with_error {
 }
 
 pub async fn run(attest_args: AttestArgs) -> i32 {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     let config = unwrap_or_exit_with_error!(CageConfig::try_from_filepath(&attest_args.config));
     let domain = unwrap_or_exit_with_error!(config.get_cage_domain());
 

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -3,6 +3,7 @@ use crate::build::build_enclave_image_file;
 use crate::common::{prepare_build_args, CliError};
 use crate::config::{read_and_validate_config, BuildTimeConfig, RuntimeVersions};
 use crate::docker::command::get_source_date_epoch;
+use crate::version::check_version;
 use clap::Parser;
 
 /// Build a Cage from a Dockerfile
@@ -73,6 +74,11 @@ impl BuildTimeConfig for BuildArgs {
 }
 
 pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     let (mut cage_config, validated_config) =
         match read_and_validate_config(&build_args.config, &build_args) {
             Ok(config) => config,

--- a/src/cli/cert.rs
+++ b/src/cli/cert.rs
@@ -2,6 +2,7 @@ use crate::cert::{self, DistinguishedName};
 use crate::common::CliError;
 use crate::config::CageConfig;
 use crate::get_api_key;
+use crate::version::check_version;
 use atty::Stream;
 use clap::{Parser, Subcommand};
 use exitcode::DATAERR;
@@ -64,6 +65,11 @@ pub struct LockCertArgs {
 }
 
 pub async fn run(cert_args: CertArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     match cert_args.action {
         CertCommands::New(new_args) => {
             let distinguished_name =

--- a/src/cli/delete.rs
+++ b/src/cli/delete.rs
@@ -1,6 +1,7 @@
 use crate::common::CliError;
 use crate::delete::delete_cage;
 use crate::get_api_key;
+use crate::version::check_version;
 use clap::Parser;
 
 /// Delete a Cage from a toml file.
@@ -28,6 +29,10 @@ pub struct DeleteArgs {
 }
 
 pub async fn run(delete_args: DeleteArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
     let should_del = match dialoguer::Confirm::new()
         .with_prompt("Are you sure you want to delete this Cage?")
         .default(false)

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -3,6 +3,7 @@ use crate::build::build_enclave_image_file;
 use crate::common::prepare_build_args;
 use crate::docker::command::get_source_date_epoch;
 use crate::get_api_key;
+use crate::version::check_version;
 use crate::{
     common::{CliError, OutputPath},
     config::{read_and_validate_config, BuildTimeConfig, ValidatedCageBuildConfig},
@@ -77,6 +78,10 @@ impl BuildTimeConfig for DeployArgs {
 }
 
 pub async fn run(deploy_args: DeployArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
     let api_key = get_api_key!();
     let (mut cage_config, validated_config) =
         match read_and_validate_config(&deploy_args.config, &deploy_args) {

--- a/src/cli/describe.rs
+++ b/src/cli/describe.rs
@@ -1,5 +1,6 @@
 use crate::common::CliError;
 use crate::describe::describe_eif;
+use crate::version::check_version;
 use clap::Parser;
 
 /// Get the PCRs of a built EIF
@@ -16,6 +17,11 @@ pub struct DescribeArgs {
 }
 
 pub async fn run(describe_args: DescribeArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     let description = match describe_eif(&describe_args.eif_path, !describe_args.quiet) {
         Ok(measurements) => measurements,
         Err(e) => {

--- a/src/cli/dev.rs
+++ b/src/cli/dev.rs
@@ -1,4 +1,5 @@
 use crate::dev::run_mock_crypto_api;
+use crate::version::check_version;
 use clap::Parser;
 
 /// Start a mock encryption API for local testing
@@ -11,6 +12,11 @@ pub struct DevArgs {
 }
 
 pub async fn run(dev_args: DevArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     run_mock_crypto_api(dev_args.port).await;
     exitcode::OK
 }

--- a/src/cli/encrypt.rs
+++ b/src/cli/encrypt.rs
@@ -1,3 +1,4 @@
+use crate::version::check_version;
 use crate::{
     config::CageConfig,
     encrypt::{self, EncryptError},
@@ -35,6 +36,11 @@ pub struct EncryptArgs {
 }
 
 pub async fn run(encrypt_args: EncryptArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     let (team_uuid, app_uuid) = match get_cage_details(encrypt_args.clone()) {
         Ok((team_uuid, app_uuid)) => (team_uuid, app_uuid),
         Err(e) => {

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -1,3 +1,4 @@
+use crate::version::check_version;
 use clap::{Parser, Subcommand};
 
 use crate::{
@@ -82,6 +83,11 @@ pub struct GetEnvArgs {
 }
 
 pub async fn run(env_args: EnvArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     let api_key = get_api_key!();
     let cages_client = CagesClient::new(AuthMode::ApiKey(api_key));
 

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -4,6 +4,7 @@ use crate::api::{cage::Cage, AuthMode};
 use crate::common::CliError;
 use crate::config::{default_dockerfile, CageConfig, EgressSettings, SigningInfo};
 use crate::get_api_key;
+use crate::version::check_version;
 use clap::{ArgGroup, Parser};
 
 /// Initialize a Cage.toml in the current directory
@@ -126,6 +127,11 @@ fn convert_comma_list(maybe_str: Option<String>) -> Option<Vec<String>> {
 }
 
 pub async fn run(init_args: InitArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     let api_key = get_api_key!();
     let cages_client = api::cage::CagesClient::new(AuthMode::ApiKey(api_key.clone()));
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,6 +1,7 @@
 use crate::api::AuthMode;
 use crate::common::CliError;
 use crate::config::{read_and_validate_config, BuildTimeConfig};
+use crate::version::check_version;
 use crate::{api, get_api_key};
 use clap::Parser;
 
@@ -38,6 +39,11 @@ pub struct DeploymentArgs {
 impl BuildTimeConfig for DeploymentArgs {}
 
 pub async fn run(list_action: List) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     let api_key = get_api_key!();
     let auth = AuthMode::ApiKey(api_key);
 

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -3,6 +3,7 @@ use crate::api::AuthMode;
 use crate::common::CliError;
 use crate::config::CageConfig;
 use crate::get_api_key;
+use crate::version::check_version;
 
 use chrono::TimeZone;
 use clap::Parser;
@@ -22,6 +23,11 @@ pub struct LogArgs {
 }
 
 pub async fn run(log_args: LogArgs) -> i32 {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     let api_key = get_api_key!();
     let cages_client = api::cage::CagesClient::new(AuthMode::ApiKey(api_key));
 

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -1,3 +1,4 @@
+use crate::version::check_version;
 use crate::{
     api::{cage::CagesClient, AuthMode},
     common::CliError,
@@ -26,6 +27,11 @@ pub struct RestartArgs {
 }
 
 pub async fn run(restart_args: RestartArgs) -> i32 {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
     let api_key = get_api_key!();
 
     let cage_api = CagesClient::new(AuthMode::ApiKey(api_key.to_string()));

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -1,3 +1,4 @@
+use crate::version::check_version;
 use crate::{api, common::CliError};
 use clap::Parser;
 use dialoguer::Confirm;
@@ -11,6 +12,11 @@ pub struct UpdateArgs {
 }
 
 pub async fn run(args: UpdateArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    }
+
     let assets_client = api::assets::AssetsClient::new();
     let new_version = match assets_client.get_latest_cli_version().await {
         Ok(version) => version,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod encrypt;
 pub mod env;
 pub mod progress;
 pub mod restart;
+mod version;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -1,9 +1,9 @@
+use crate::api::assets::AssetsClient;
+use crate::api::client::ApiError;
 use chrono::Utc;
 use semver::Version;
 use std::env;
 use thiserror::Error;
-use crate::api::assets::AssetsClient;
-use crate::api::client::ApiError;
 
 #[derive(Debug, Error)]
 pub enum VersionError {
@@ -24,7 +24,9 @@ fn get_latest_major_version() -> Result<u8, VersionError> {
 }
 
 pub async fn check_version() -> Result<(), VersionError> {
-    if std::env::var("EV_DOMAIN").unwrap_or_else(|_| String::from("evervault.com")) == "evervault.io" {
+    if std::env::var("EV_DOMAIN").unwrap_or_else(|_| String::from("evervault.com"))
+        == "evervault.io"
+    {
         return Ok(());
     }
     match alert_on_deprecation().await? {
@@ -39,10 +41,11 @@ async fn alert_on_deprecation() -> Result<Option<i64>, VersionError> {
     let installed_major_version = get_latest_major_version()?;
     let installed_semver = Version::parse(env!("CARGO_PKG_VERSION"))?;
     let current_version = match version_info
-    .versions
-    .get(&installed_major_version.to_string()) {
+        .versions
+        .get(&installed_major_version.to_string())
+    {
         Some(version) => version,
-        None => return Err(VersionError::VersionCheckError)
+        None => return Err(VersionError::VersionCheckError),
     };
     let latest_semver = Version::parse(current_version.latest.as_str())?;
     if let Some(deprecation_date) = &current_version.deprecation_date {

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -1,0 +1,66 @@
+use chrono::Utc;
+use semver::Version;
+use std::env;
+use thiserror::Error;
+use crate::api::assets::AssetsClient;
+use crate::api::client::ApiError;
+
+#[derive(Debug, Error)]
+pub enum VersionError {
+    #[error("An error occurred getting CLI versions — {0}")]
+    ApiError(#[from] ApiError),
+    #[error("Couldn't parse the semver version - {0}")]
+    SemVerError(#[from] semver::Error),
+    #[error("Couldn't parse env string as int - {0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+    #[error("This version is deprecated, please run ev-cage update to continue")]
+    DeprecationError,
+    #[error("Couldn't check version against latest")]
+    VersionCheckError,
+}
+
+fn get_latest_major_version() -> Result<u8, VersionError> {
+    Ok(env!("CARGO_PKG_VERSION_MAJOR").parse::<u8>()?)
+}
+
+pub async fn check_version() -> Result<(), VersionError> {
+    if std::env::var("EV_DOMAIN").unwrap_or_else(|_| String::from("evervault.com")) == "evervault.io" {
+        return Ok(());
+    }
+    match alert_on_deprecation().await? {
+        Some(_) => Err(VersionError::DeprecationError),
+        _ => Ok(()),
+    }
+}
+
+async fn alert_on_deprecation() -> Result<Option<i64>, VersionError> {
+    let assets_client = AssetsClient::new();
+    let version_info = assets_client.get_cli_versions().await?;
+    let installed_major_version = get_latest_major_version()?;
+    let installed_semver = Version::parse(env!("CARGO_PKG_VERSION"))?;
+    let current_version = match version_info
+    .versions
+    .get(&installed_major_version.to_string()) {
+        Some(version) => version,
+        None => return Err(VersionError::VersionCheckError)
+    };
+    let latest_semver = Version::parse(current_version.latest.as_str())?;
+    if let Some(deprecation_date) = &current_version.deprecation_date {
+        let current_time = Utc::now().timestamp();
+        if current_time > deprecation_date.parse::<i64>()? {
+            return Ok(Some(deprecation_date.parse::<i64>()?));
+        } else {
+            log::warn!(
+                "This major version will be deprecated on {}",
+                deprecation_date
+            );
+        }
+    } else if installed_semver < latest_semver {
+        log::warn!(
+            "You are behind the latest version. Installed version: {}, latest version {}",
+            installed_semver,
+            latest_semver
+        );
+    }
+    Ok(None)
+}


### PR DESCRIPTION
# Why
We need to encourage regular upgrades and also block usage if the CLI version is deprecated

# How
- Warn when version is behind latest
- Error when version is deprecated
