### PR TITLE
Pull latest major runtime version dependent on the CLI major version

### DIFF
--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -1,24 +1,32 @@
 use super::client::{ApiClient, ApiClientError, ApiResult, GenericApiClient, HandleResponse};
+use crate::api::client::ApiError;
+use crate::api::client::ApiErrorKind;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-#[derive(Deserialize)]
-#[serde(rename_all = "kebab-case")]
-struct RuntimeVersion {
-    data_plane: String,
-}
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CLIVersion {
     pub latest: String,
-    pub versions: HashMap<String, MajorVersion>,
+    pub versions: HashMap<String, CLIMajorVersion>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct MajorVersion {
+pub struct CLIMajorVersion {
     pub latest: String,
     #[serde(rename = "deprecationDate")]
     pub deprecation_date: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RuntimeVersion {
+    pub latest: String,
+    pub versions: HashMap<String, RuntimeMajorVersion>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct RuntimeMajorVersion {
+    pub latest: String,
+    pub installer: String,
 }
 
 pub struct AssetsClient {
@@ -76,24 +84,29 @@ impl AssetsClient {
             .await
     }
 
-    pub async fn get_latest_data_plane_version(&self) -> ApiResult<String> {
-        let data_plane_version = format!("{}/runtime/latest", self.base_url());
-        self.get(&data_plane_version)
+    pub async fn get_data_plane_version(&self) -> ApiResult<String> {
+        self.get_runtime_versions().await
+            .map(|version| version.latest)
+    }
+
+    pub async fn get_installer_version(&self) -> ApiResult<String> {
+        self.get_runtime_versions().await
+            .map(|version| version.installer)
+    }
+
+    pub async fn get_runtime_versions(&self) -> ApiResult<RuntimeMajorVersion> {
+        let installed_major_version = env!("CARGO_PKG_VERSION_MAJOR");
+        let data_plane_version = format!("{}/runtime/versions", self.base_url());
+        let result = self
+            .get(&data_plane_version)
             .send()
             .await
             .handle_json_response::<RuntimeVersion>()
-            .await
-            .map(|version| version.data_plane)
-    }
-
-    pub async fn get_latest_installer_version(&self) -> ApiResult<String> {
-        let installer_version = format!("{}/installer/latest", self.base_url());
-        self.get(&installer_version)
-            .send()
-            .await
-            .handle_text_response()
-            .await
-            .map(|version| version.trim().to_string())
+            .await?;
+        match result.versions.get(installed_major_version) {
+            Some(versions) => Ok(versions.clone()),
+            None => Err(ApiError::new(ApiErrorKind::NotFound)),
+        }
     }
 
     pub async fn get_cli_versions(&self) -> ApiResult<CLIVersion> {

--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -85,12 +85,14 @@ impl AssetsClient {
     }
 
     pub async fn get_data_plane_version(&self) -> ApiResult<String> {
-        self.get_runtime_versions().await
+        self.get_runtime_versions()
+            .await
             .map(|version| version.latest)
     }
 
     pub async fn get_installer_version(&self) -> ApiResult<String> {
-        self.get_runtime_versions().await
+        self.get_runtime_versions()
+            .await
             .map(|version| version.installer)
     }
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -162,8 +162,8 @@ pub enum ApiErrorKind {
 }
 
 pub struct ApiError {
-    kind: ApiErrorKind,
-    details: Option<ApiErrorDetails>,
+    pub kind: ApiErrorKind,
+    pub details: Option<ApiErrorDetails>,
 }
 
 pub type ApiResult<T> = core::result::Result<T, ApiError>;

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -94,10 +94,7 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         .map(|args| args.iter().map(AsRef::as_ref).collect());
 
     let cage_build_assets_client = AssetsClient::new();
-    let data_plane_version = match cage_build_assets_client
-        .get_latest_data_plane_version()
-        .await
-    {
+    let data_plane_version = match cage_build_assets_client.get_data_plane_version().await {
         Ok(version) => version,
         Err(e) => {
             log::error!("Failed to retrieve the latest data plane version - {e:?}");
@@ -105,10 +102,7 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         }
     };
 
-    let installer_version = match cage_build_assets_client
-        .get_latest_installer_version()
-        .await
-    {
+    let installer_version = match cage_build_assets_client.get_installer_version().await {
         Ok(version) => version,
         Err(e) => {
             log::error!("Failed to retrieve the latest installer version - {e:?}");

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -228,20 +228,14 @@ async fn get_data_plane_and_installer_version(
     match validated_config.runtime.clone() {
         Some(config) => Ok((config.data_plane_version.clone(), config.installer_version)),
         None => {
-            let data_plane_version = match cage_build_assets_client
-                .get_latest_data_plane_version()
-                .await
-            {
+            let data_plane_version = match cage_build_assets_client.get_data_plane_version().await {
                 Ok(version) => version,
                 Err(e) => {
                     log::error!("Failed to retrieve the latest data plane version - {e:?}");
                     return Err(e.exitcode());
                 }
             };
-            let installer_version = match cage_build_assets_client
-                .get_latest_installer_version()
-                .await
-            {
+            let installer_version = match cage_build_assets_client.get_installer_version().await {
                 Ok(version) => version,
                 Err(e) => {
                     log::error!("Failed to retrieve the latest installer version - {e:?}");

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -16,8 +16,8 @@ pub async fn build_test_cage(
     let build_args = get_test_build_args();
     let assets_client = AssetsClient::new();
 
-    let data_plane_version = assets_client.get_latest_data_plane_version().await.unwrap();
-    let installer_version = assets_client.get_latest_installer_version().await.unwrap();
+    let data_plane_version = assets_client.get_data_plane_version().await.unwrap();
+    let installer_version = assets_client.get_installer_version().await.unwrap();
     let timestamp = "0".to_string();
 
     build_enclave_image_file(

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -19,7 +19,7 @@ pub enum VersionError {
     VersionCheckError,
 }
 
-fn get_latest_major_version() -> Result<u8, VersionError> {
+pub fn get_latest_major_version() -> Result<u8, VersionError> {
     Ok(env!("CARGO_PKG_VERSION_MAJOR").parse::<u8>()?)
 }
 


### PR DESCRIPTION
# Why
We need to ensure the CLIs major version dictates the version of the runtime

# How
Pull the installer and data plane with the same major version as the CLI
