### PR TITLE
Add Cage's scaling command

### DIFF
--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -801,12 +801,14 @@ impl CageScalingConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ScalingLimits {
     max_instances: u32,
     available_instances: u32,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ScalingConfig {
     desired_replicas: u32,
 }

--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -227,6 +227,29 @@ impl CagesClient {
             .handle_json_response()
             .await
     }
+
+    pub async fn get_scaling_config(&self, cage_uuid: &str) -> ApiResult<CageScalingConfig> {
+        let cage_scaling_url = format!("{}/{}/scale", self.base_url(), cage_uuid);
+        self.get(&cage_scaling_url)
+            .send()
+            .await
+            .handle_json_response()
+            .await
+    }
+
+    pub async fn update_scaling_config(
+        &self,
+        cage_uuid: &str,
+        update_scaling_config_request: UpdateCageScalingConfigRequest,
+    ) -> ApiResult<CageScalingConfig> {
+        let cage_scaling_url = format!("{}/{}/scale", self.base_url(), cage_uuid);
+        self.put(&cage_scaling_url)
+            .json(&update_scaling_config_request)
+            .send()
+            .await
+            .handle_json_response()
+            .await
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -756,6 +779,47 @@ impl LogEvent {
 }
 
 pub type DeleteCageResponse = Cage;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CageScalingConfig {
+    limits: ScalingLimits,
+    config: ScalingConfig,
+}
+
+impl CageScalingConfig {
+    pub fn max_instances(&self) -> u32 {
+        self.limits.max_instances
+    }
+
+    pub fn available_instances(&self) -> u32 {
+        self.limits.available_instances
+    }
+
+    pub fn desired_replicas(&self) -> u32 {
+        self.config.desired_replicas
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ScalingLimits {
+    max_instances: u32,
+    available_instances: u32,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ScalingConfig {
+    desired_replicas: u32,
+}
+
+impl std::convert::From<u32> for ScalingConfig {
+    fn from(value: u32) -> Self {
+        Self {
+            desired_replicas: value,
+        }
+    }
+}
+
+pub type UpdateCageScalingConfigRequest = ScalingConfig;
 
 #[cfg(test)]
 mod test {

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -136,12 +136,9 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         }
     };
 
-    crate::common::update_cage_config_with_eif_measurements(
-        &mut cage_config,
-        &build_args.config,
-        built_enclave.measurements(),
-        Some(runtime_info),
-    );
+    cage_config.set_attestation(built_enclave.measurements());
+    cage_config.set_runtime_info(runtime_info);
+    crate::common::save_cage_config(&cage_config, &build_args.config);
 
     if cage_config.debug {
         crate::common::log_debug_mode_attestation_warning();

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -147,12 +147,8 @@ pub async fn run(deploy_args: DeployArgs) -> exitcode::ExitCode {
             .expect("Failed to serialize Cage attestation measures.")
     );
 
-    crate::common::update_cage_config_with_eif_measurements(
-        &mut cage_config,
-        &deploy_args.config,
-        &eif_measurements,
-        None,
-    );
+    cage_config.set_attestation(&eif_measurements);
+    crate::common::save_cage_config(&cage_config, &deploy_args.config);
 
     if let Err(e) = deploy_eif(
         &validated_config,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,6 +13,7 @@ pub mod init;
 pub mod list;
 pub mod logs;
 pub mod restart;
+pub mod scale;
 pub mod update;
 
 #[derive(Debug, Subcommand)]
@@ -32,4 +33,5 @@ pub enum Command {
     Env(env::EnvArgs),
     Encrypt(encrypt::EncryptArgs),
     Restart(restart::RestartArgs),
+    Scale(scale::ScaleArgs),
 }

--- a/src/cli/scale.rs
+++ b/src/cli/scale.rs
@@ -112,7 +112,7 @@ pub async fn run(args: ScaleArgs) -> i32 {
             .scaling
             .as_ref()
             .is_some_and(|scaling| scaling.desired_replicas != scaling_config.desired_replicas());
-        if args.sync && has_scaling_drift {
+        if (args.sync && args.desired_instances.is_some()) && has_scaling_drift {
             config.set_scaling_config(ScalingSettings {
                 desired_replicas: scaling_config.desired_replicas(),
             });
@@ -121,17 +121,17 @@ pub async fn run(args: ScaleArgs) -> i32 {
     }
 
     if atty::is(atty::Stream::Stdout) {
-        log::info!(
+        println!(
             "{}",
             serde_json::to_string_pretty(&scaling_config)
                 .expect("Failed to serialize scaling config")
         );
     } else {
-        log::info!(
+        println!(
             "{}",
             serde_json::to_string(&scaling_config).expect("Failed to serialize scaling config")
         );
     }
 
-    return exitcode::OK;
+    exitcode::OK
 }

--- a/src/cli/scale.rs
+++ b/src/cli/scale.rs
@@ -1,0 +1,137 @@
+use crate::config::{self, ScalingSettings};
+use crate::version::check_version;
+use crate::{
+    api::{cage::CagesClient, AuthMode},
+    common::CliError,
+    config::CageConfig,
+    get_api_key,
+};
+use clap::Parser;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ScaleError {
+    #[error("No Cage Uuid given. You can provide one by using either the --cage-uuid flag, or using the --config flag to point to a Cage.toml")]
+    MissingUuid,
+    #[error("An error occurred parsing the Cage config - {0}")]
+    ConfigError(#[from] config::CageConfigError),
+    #[error("An error occurred contacting the API — {0}")]
+    ApiError(#[from] crate::api::client::ApiError),
+}
+
+impl CliError for ScaleError {
+    fn exitcode(&self) -> exitcode::ExitCode {
+        match self {
+            Self::MissingUuid => exitcode::CONFIG,
+            Self::ConfigError(inner) => inner.exitcode(),
+            Self::ApiError(inner) => inner.exitcode(),
+        }
+    }
+}
+
+/// Update your Cage's Scaling config
+#[derive(Debug, Parser)]
+#[clap(name = "scale", about)]
+pub struct ScaleArgs {
+    /// Path to cage.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    pub config: String,
+
+    /// Uuid of the Cage to scale
+    #[clap(long = "cage-uuid")]
+    pub cage_uuid: Option<String>,
+
+    /// Number of instances to run for this Cage. If unset, the command will read the current scaling config from the Evervault API.
+    #[clap(long = "desired-instances")]
+    pub desired_instances: Option<u32>,
+
+    /// Sync the local Cage.toml with the latest scaling config for a Cage if they differ.
+    #[clap(long = "sync")]
+    pub sync: bool,
+}
+
+pub async fn run(args: ScaleArgs) -> i32 {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
+    let api_key = get_api_key!();
+
+    let cage_api = CagesClient::new(AuthMode::ApiKey(api_key.to_string()));
+
+    let cage_config = CageConfig::try_from_filepath(&args.config);
+    let cage_uuid = match args.cage_uuid.as_deref() {
+        Some(cage_uuid) => Ok(cage_uuid),
+        None => match cage_config.as_ref() {
+            Ok(cage_config) => cage_config.uuid.as_deref().ok_or(ScaleError::MissingUuid),
+            Err(e) => {
+                log::error!("Failed to resolve cage config - {e:?}");
+                return e.exitcode();
+            }
+        },
+    };
+
+    let cage_uuid = match cage_uuid {
+        Ok(cage_uuid) => cage_uuid,
+        Err(e) => {
+            log::error!("{e:?}");
+            return e.exitcode();
+        }
+    };
+
+    let scaling_config_result = match args.desired_instances {
+        Some(new_desired_instances) => {
+            log::info!("Updating desired replicas to {new_desired_instances}");
+            cage_api
+                .update_scaling_config(&cage_uuid, new_desired_instances.into())
+                .await
+        }
+        None => cage_api.get_scaling_config(&cage_uuid).await,
+    };
+
+    let scaling_config = match scaling_config_result {
+        Ok(result) if args.desired_instances.is_some() => {
+            log::info!("Cage scaling config updated successfully");
+            result
+        }
+        Ok(result) => result,
+        Err(e) => {
+            let action = if args.desired_instances.is_some() {
+                "update"
+            } else {
+                "read"
+            };
+            log::error!("Failed to {action} the scaling config for {cage_uuid} - {e:?}");
+            return e.exitcode();
+        }
+    };
+
+    if let Ok(mut config) = cage_config {
+        let has_scaling_drift = config
+            .scaling
+            .as_ref()
+            .is_some_and(|scaling| scaling.desired_replicas != scaling_config.desired_replicas());
+        if args.sync && has_scaling_drift {
+            config.set_scaling_config(ScalingSettings {
+                desired_replicas: scaling_config.desired_replicas(),
+            });
+            crate::common::save_cage_config(&config, &args.config);
+        }
+    }
+
+    if atty::is(atty::Stream::Stdout) {
+        log::info!(
+            "{}",
+            serde_json::to_string_pretty(&scaling_config)
+                .expect("Failed to serialize scaling config")
+        );
+    } else {
+        log::info!(
+            "{}",
+            serde_json::to_string(&scaling_config).expect("Failed to serialize scaling config")
+        );
+    }
+
+    return exitcode::OK;
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -420,6 +420,10 @@ impl CageConfig {
         self.runtime = Some(runtime.clone());
     }
 
+    pub fn set_scaling_config(&mut self, scaling_info: ScalingSettings) {
+        self.scaling = Some(scaling_info);
+    }
+
     pub fn try_from_filepath(path: &str) -> Result<Self, CageConfigError> {
         let config_path = std::path::Path::new(path);
         if !config_path.exists() {

--- a/src/delete/mod.rs
+++ b/src/delete/mod.rs
@@ -1,21 +1,9 @@
 use crate::api;
 use crate::api::cage::CagesClient;
 use crate::api::AuthMode;
-use crate::config::{CageConfig, CageConfigError};
 use crate::progress::{get_tracker, poll_fn_and_report_status, ProgressLogger, StatusReport};
 mod error;
 use error::DeleteError;
-
-fn resolve_cage_uuid(
-    given_uuid: Option<&str>,
-    config_path: &str,
-) -> Result<Option<String>, CageConfigError> {
-    if let Some(given_uuid) = given_uuid {
-        return Ok(Some(given_uuid.to_string()));
-    }
-    let config = CageConfig::try_from_filepath(config_path)?;
-    Ok(config.uuid)
-}
 
 pub async fn delete_cage(
     config: &str,
@@ -23,7 +11,7 @@ pub async fn delete_cage(
     api_key: &str,
     background: bool,
 ) -> Result<(), DeleteError> {
-    let maybe_cage_uuid = resolve_cage_uuid(cage_uuid, config)?;
+    let maybe_cage_uuid = crate::common::resolve_cage_uuid(cage_uuid, config)?;
     let cage_uuid = match maybe_cage_uuid {
         Some(given_cage_uuid) => given_cage_uuid,
         _ => return Err(DeleteError::MissingUuid),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ use env_logger::{Builder, Env};
 #[cfg(not(target_os = "windows"))]
 use ev_cage::cli::attest;
 use ev_cage::cli::{
-    build, cert, delete, deploy, describe, dev, encrypt, env, init, list, logs, restart, update,
-    Command,
+    build, cert, delete, deploy, describe, dev, encrypt, env, init, list, logs, restart, scale,
+    update, Command,
 };
 use human_panic::setup_panic;
 use log::Record;
@@ -61,6 +61,7 @@ async fn main() {
         Command::Env(env_args) => env::run(env_args).await,
         Command::Encrypt(env_args) => encrypt::run(env_args).await,
         Command::Restart(restart_args) => restart::run(restart_args).await,
+        Command::Scale(scale_args) => scale::run(scale_args).await,
     };
     std::process::exit(exit_code);
 }

--- a/src/restart/mod.rs
+++ b/src/restart/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     api::cage::{CageDeployment, CagesClient},
     common::CliError,
-    config::{CageConfig, CageConfigError},
 };
 use thiserror::Error;
 
@@ -28,24 +27,13 @@ impl CliError for RestartError {
     }
 }
 
-fn resolve_cage_uuid(
-    given_uuid: Option<&str>,
-    config_path: &str,
-) -> Result<Option<String>, CageConfigError> {
-    if let Some(given_uuid) = given_uuid {
-        return Ok(Some(given_uuid.to_string()));
-    }
-    let config = CageConfig::try_from_filepath(config_path)?;
-    Ok(config.uuid)
-}
-
 pub async fn restart_cage(
     config: &str,
     cage_uuid: Option<&str>,
     cage_api: &CagesClient,
     _background: bool,
 ) -> Result<CageDeployment, RestartError> {
-    let maybe_cage_uuid = resolve_cage_uuid(cage_uuid, config)?;
+    let maybe_cage_uuid = crate::common::resolve_cage_uuid(cage_uuid, config)?;
     let cage_uuid = match maybe_cage_uuid {
         Some(given_cage_uuid) => given_cage_uuid,
         _ => return Err(RestartError::MissingUuid),


### PR DESCRIPTION
# Why
Scaling a cage currently requires requesting the public API directly. Adding a command keeps the interface for Cages more consistent

# How
Add scaling command to scale cages up and down on demand. Included a `--sync` flag which updates the cage toml when it falls out of sync.

## Usage

Read scaling config (including the `--sync` flag will update the cage.toml when there's drift with the current state):
```sh
> ev-cage scale
{
  "limits": {
    "maxInstances": 2,
    "availableInstances": 1
  },
  "config": {
    "desiredReplicas": 1
  }
}
```

Write scaling config (will always write to the cage.toml):
```sh
> ev-cage scale --desired-replicas 2
{
  "limits": {
    "maxInstances": 2,
    "availableInstances": 0
  },
  "config": {
    "desiredReplicas": 2
  }
}
```
