### PR TITLE
Only send scaling config in deploy request if specified in toml

### DIFF
--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -277,7 +277,7 @@ pub struct CreateCageDeploymentIntentRequest {
     metadata: VersionMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
     healthcheck: Option<String>,
-    desired_replicas: u32,
+    desired_replicas: Option<u32>,
 }
 
 impl CreateCageDeploymentIntentRequest {
@@ -290,7 +290,7 @@ impl CreateCageDeploymentIntentRequest {
         git_timestamp: String,
         git_hash: String,
         healthcheck: Option<String>,
-        desired_replicas: u32,
+        desired_replicas: Option<u32>,
     ) -> Self {
         Self {
             pcrs: pcrs.clone(),

--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -331,6 +331,7 @@ pub struct CreateCageDeploymentIntentRequest {
     metadata: VersionMetadata,
     #[serde(skip_serializing_if = "Option::is_none")]
     healthcheck: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     desired_replicas: Option<u32>,
 }
 

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -461,9 +461,9 @@ mod test {
                 destinations: None,
                 ports: Some(vec!["433".to_string()]),
             },
-            scaling: ScalingSettings {
-                desired_replicas: 2,
-            },
+            scaling: Some(ScalingSettings {
+                desired_replicas: Some(2),
+            }),
             attestation: None,
             signing: ValidatedSigningInfo {
                 cert: "".into(),

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -462,7 +462,7 @@ mod test {
                 ports: Some(vec!["433".to_string()]),
             },
             scaling: Some(ScalingSettings {
-                desired_replicas: Some(2),
+                desired_replicas: 2,
             }),
             attestation: None,
             signing: ValidatedSigningInfo {

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -118,13 +118,12 @@ pub async fn run(deploy_args: DeployArgs) -> exitcode::ExitCode {
     let local_replicas = validated_config
         .scaling
         .as_ref()
-        .and_then(|local_scaling_config| local_scaling_config.desired_replicas);
+        .map(|local_scaling_config| local_scaling_config.desired_replicas);
 
     // Warn if local scaling config differs from remote
-    let has_scaling_config_drift = cage_scaling_config
-        .as_ref()
-        .and_then(|config| local_replicas.map(|replicas| config.desired_replicas() != replicas))
-        .unwrap_or(true);
+    let has_scaling_config_drift = cage_scaling_config.as_ref().is_some_and(|config| {
+        local_replicas.is_some_and(|replicas| config.desired_replicas() != replicas)
+    });
 
     if has_scaling_config_drift && cage_scaling_config.is_some() {
         let remote_replicas = cage_scaling_config.as_ref().unwrap().desired_replicas();

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -115,15 +115,24 @@ pub async fn run(deploy_args: DeployArgs) -> exitcode::ExitCode {
         }
     };
 
-    let local_replicas = validated_config.scaling.desired_replicas;
+    let local_replicas = validated_config
+        .scaling
+        .as_ref()
+        .and_then(|local_scaling_config| local_scaling_config.desired_replicas);
 
     // Warn if local scaling config differs from remote
     let has_scaling_config_drift = cage_scaling_config
         .as_ref()
-        .is_some_and(|config| config.desired_replicas() != local_replicas);
-    if has_scaling_config_drift {
+        .and_then(|config| local_replicas.map(|replicas| config.desired_replicas() != replicas))
+        .unwrap_or(true);
+
+    if has_scaling_config_drift && cage_scaling_config.is_some() {
         let remote_replicas = cage_scaling_config.as_ref().unwrap().desired_replicas();
-        log::warn!("Remote scaling config differs from local config. This deployment will apply the local config.\n\nCurrent remote replica count: {remote_replicas}\nLocal replica count: {local_replicas}\n");
+        let local_replicas_count = local_replicas
+            .map(|count| count.to_string())
+            .unwrap_or(String::from("not_set"));
+
+        log::warn!("Remote scaling config differs from local config. This deployment will apply the local config.\n\nCurrent remote replica count: {remote_replicas}\nLocal replica count: {local_replicas_count}\n");
     }
 
     let timestamp = get_source_date_epoch();

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -125,11 +125,15 @@ pub async fn run(deploy_args: DeployArgs) -> exitcode::ExitCode {
         local_replicas.is_some_and(|replicas| config.desired_replicas() != replicas)
     });
 
-    if has_scaling_config_drift && cage_scaling_config.is_some() {
+    // cage scaling config is None - has_scaling_config_drift: false
+    // cage scaling config is Some - local scaling config is None : has_scaling_config_drift: false
+    // cage scaling config is Some - local scaling config is Some - scaling config differs : has_scaling_config_drift: true
+
+    if has_scaling_config_drift {
         let remote_replicas = cage_scaling_config.as_ref().unwrap().desired_replicas();
         let local_replicas_count = local_replicas
             .map(|count| count.to_string())
-            .unwrap_or(String::from("not_set"));
+            .expect("Infallible - checked above");
 
         log::warn!("Remote scaling config differs from local config. This deployment will apply the local config.\n\nCurrent remote replica count: {remote_replicas}\nLocal replica count: {local_replicas_count}\n");
     }

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -112,9 +112,11 @@ impl std::convert::From<InitArgs> for CageConfig {
                 convert_comma_list(val.egress_destinations),
                 val.egress,
             ),
-            scaling: Some(ScalingSettings {
-                desired_replicas: val.desired_replicas.unwrap_or(2),
-            }),
+            scaling: val
+                .desired_replicas
+                .map(|desired_replicas| ScalingSettings {
+                    desired_replicas: Some(desired_replicas),
+                }),
             dockerfile: val.dockerfile.unwrap_or_else(default_dockerfile), // need to manually set default dockerfile
             signing: signing_info,
             attestation: None,

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -114,9 +114,7 @@ impl std::convert::From<InitArgs> for CageConfig {
             ),
             scaling: val
                 .desired_replicas
-                .map(|desired_replicas| ScalingSettings {
-                    desired_replicas: Some(desired_replicas),
-                }),
+                .map(|desired_replicas| ScalingSettings { desired_replicas }),
             dockerfile: val.dockerfile.unwrap_or_else(default_dockerfile), // need to manually set default dockerfile
             signing: signing_info,
             attestation: None,

--- a/src/cli/scale.rs
+++ b/src/cli/scale.rs
@@ -111,17 +111,13 @@ pub async fn run(args: ScaleArgs) -> i32 {
         let has_scaling_drift = config
             .scaling
             .as_ref()
-            .map(|config_scaling_settings| {
-                config_scaling_settings
-                    .desired_replicas
-                    .map(|desired_replicas| desired_replicas != scaling_config.desired_replicas())
-                    .unwrap_or(true) // desired_replicas is not set in the config
-            })
-            .unwrap_or(true); // scaling config not set in the config
+            .is_some_and(|config_scaling_settings| {
+                config_scaling_settings.desired_replicas != scaling_config.desired_replicas()
+            });
 
         if (args.sync || args.desired_replicas.is_some()) && has_scaling_drift {
             config.set_scaling_config(ScalingSettings {
-                desired_replicas: Some(scaling_config.desired_replicas()),
+                desired_replicas: scaling_config.desired_replicas(),
             });
             crate::common::save_cage_config(&config, &args.config);
         }

--- a/src/cli/scale.rs
+++ b/src/cli/scale.rs
@@ -115,9 +115,9 @@ pub async fn run(args: ScaleArgs) -> i32 {
                 config_scaling_settings
                     .desired_replicas
                     .map(|desired_replicas| desired_replicas != scaling_config.desired_replicas())
-                    .unwrap_or(false) // desired_replicas is not set in the config
+                    .unwrap_or(true) // desired_replicas is not set in the config
             })
-            .unwrap_or(false); // scaling config not set in the config
+            .unwrap_or(true); // scaling config not set in the config
 
         if (args.sync || args.desired_replicas.is_some()) && has_scaling_drift {
             config.set_scaling_config(ScalingSettings {

--- a/src/config.rs
+++ b/src/config.rs
@@ -295,7 +295,7 @@ pub struct ValidatedCageBuildConfig {
     pub debug: bool,
     pub dockerfile: String,
     pub egress: EgressSettings,
-    pub scaling: ScalingSettings,
+    pub scaling: Option<ScalingSettings>,
     pub signing: ValidatedSigningInfo,
     pub attestation: Option<EIFMeasurements>,
     pub disable_tls_termination: bool,
@@ -483,7 +483,7 @@ impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
             (true, true) => Ok(true), // (logging enabled, tls_termination enabled) = logging enabled
         }?;
 
-        let scaling_settings = config.scaling.clone().unwrap_or_default();
+        let scaling_settings = config.scaling.clone();
 
         Ok(ValidatedCageBuildConfig {
             cage_uuid,
@@ -593,7 +593,7 @@ mod test {
                 ports: Some(vec!["443".to_string()]),
             },
             scaling: Some(super::ScalingSettings {
-                desired_replicas: 2,
+                desired_replicas: Some(2),
             }),
             signing: None,
             attestation: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,23 +55,23 @@ impl EgressSettings {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ScalingSettings {
-    pub desired_replicas: u32,
+    pub desired_replicas: Option<u32>,
 }
 
 impl Default for ScalingSettings {
     fn default() -> Self {
         ScalingSettings {
-            desired_replicas: 2,
+            desired_replicas: None,
         }
     }
 }
 
 impl ScalingSettings {
-    pub fn new(desired_replicas: u32) -> ScalingSettings {
+    pub fn new(desired_replicas: Option<u32>) -> ScalingSettings {
         ScalingSettings { desired_replicas }
     }
 
-    pub fn get_desired_replicas(self) -> u32 {
+    pub fn get_desired_replicas(self) -> Option<u32> {
         self.desired_replicas
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,23 +55,23 @@ impl EgressSettings {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ScalingSettings {
-    pub desired_replicas: Option<u32>,
+    pub desired_replicas: u32,
 }
 
 impl Default for ScalingSettings {
     fn default() -> Self {
         ScalingSettings {
-            desired_replicas: None,
+            desired_replicas: 2,
         }
     }
 }
 
 impl ScalingSettings {
-    pub fn new(desired_replicas: Option<u32>) -> ScalingSettings {
+    pub fn new(desired_replicas: u32) -> ScalingSettings {
         ScalingSettings { desired_replicas }
     }
 
-    pub fn get_desired_replicas(self) -> Option<u32> {
+    pub fn get_desired_replicas(self) -> u32 {
         self.desired_replicas
     }
 }
@@ -593,7 +593,7 @@ mod test {
                 ports: Some(vec!["443".to_string()]),
             },
             scaling: Some(super::ScalingSettings {
-                desired_replicas: Some(2),
+                desired_replicas: 2,
             }),
             signing: None,
             attestation: None,

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -49,7 +49,10 @@ pub async fn deploy_eif(
         get_source_date_epoch(),
         get_git_hash(),
         validated_config.healthcheck().map(String::from),
-        validated_config.scaling.desired_replicas,
+        validated_config
+            .scaling
+            .as_ref()
+            .and_then(|config| config.desired_replicas),
     );
 
     let deployment_intent = cage_api

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -52,7 +52,7 @@ pub async fn deploy_eif(
         validated_config
             .scaling
             .as_ref()
-            .and_then(|config| config.desired_replicas),
+            .map(|config| config.desired_replicas),
     );
 
     let deployment_intent = cage_api


### PR DESCRIPTION
# Why
I had it so we were defaulting to two if not set. This means if someone had scaled, it would be overwritten.

# How
Update so the scaling table and desired_replicas field are both optional.
