### PR TITLE
Feature flag logic that uses closed source lib

### DIFF
--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           mkdir ${{ env.BIN_DIR }}
           mkdir ${{ env.RELEASE_DIR }}
-          cross build --release --target ${{ env.LINUX_TARGET }} -Z registry-auth
+          cross build --release --all-features --target ${{ env.LINUX_TARGET }} -Z registry-auth
           mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
           7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
         env:
@@ -107,7 +107,7 @@ jobs:
       - name: Build CLI MacOs Target
         run: |
           cargo install cross
-          cross build --release --target ${{ env.MACOS_TARGET }} -Z registry-auth
+          cross build --release --all-features --target ${{ env.MACOS_TARGET }} -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
@@ -166,7 +166,7 @@ jobs:
       - name: Build CLI for Windows
         run: |
           cargo install cross
-          cross build --release --target ${{ env.WINDOWS_TARGET }} -Z registry-auth
+          cross build --release --all-features --target ${{ env.WINDOWS_TARGET }} -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio-rustls = { version = "0.23", features = ["dangerous_configuration"] }
 x509-parser = "0.14.0"
 hex = "0.4.3"
 axum = "0.5.16"
-rust-crypto = { version = "0.1.21", registry="evervault-rust-libraries", features=["vendored-openssl"] }
+rust-crypto = { version = "0.1.21", registry="evervault-rust-libraries", features=["vendored-openssl"], optional = true }
 serde_cbor = "0.11"
 base64 = "0.13.0"
 aws-nitro-enclaves-image-format = "0.2.0"
@@ -54,3 +54,6 @@ serial_test = "2.0.0"
 [target.'cfg(unix)'.dependencies]
 aws-nitro-enclaves-nsm-api = { version = "0.2.1" }
 attestation-doc-validation = "0.7.3" 
+
+[features]
+internal_dependency = ["rust-crypto"]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,8 +6,11 @@ pub mod cert;
 pub mod delete;
 pub mod deploy;
 pub mod describe;
+#[cfg(feature = "internal_dependency")]
 pub mod dev;
+#[cfg(feature = "internal_dependency")]
 pub mod encrypt;
+#[cfg(feature = "internal_dependency")]
 pub mod env;
 pub mod init;
 pub mod list;
@@ -23,6 +26,7 @@ pub enum Command {
     Delete(delete::DeleteArgs),
     Describe(describe::DescribeArgs),
     Deploy(deploy::DeployArgs),
+    #[cfg(feature = "internal_dependency")]
     Dev(dev::DevArgs),
     Init(init::InitArgs),
     List(list::List),
@@ -30,7 +34,9 @@ pub enum Command {
     Update(update::UpdateArgs),
     #[cfg(not(target_os = "windows"))]
     Attest(attest::AttestArgs),
+    #[cfg(feature = "internal_dependency")]
     Env(env::EnvArgs),
+    #[cfg(feature = "internal_dependency")]
     Encrypt(encrypt::EncryptArgs),
     Restart(restart::RestartArgs),
     Scale(scale::ScaleArgs),

--- a/src/cli/scale.rs
+++ b/src/cli/scale.rs
@@ -84,10 +84,10 @@ pub async fn run(args: ScaleArgs) -> i32 {
         Some(new_desired_replicas) => {
             log::info!("Updating desired replicas to {new_desired_replicas}");
             cage_api
-                .update_scaling_config(&cage_uuid, new_desired_replicas.into())
+                .update_scaling_config(cage_uuid, new_desired_replicas.into())
                 .await
         }
-        None => cage_api.get_scaling_config(&cage_uuid).await,
+        None => cage_api.get_scaling_config(cage_uuid).await,
     };
 
     let scaling_config = match scaling_config_result {

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -2,6 +2,7 @@ use crate::api::cage::{AddSecretRequest, CageEnv, CagesClient};
 use crate::cli::env::EnvCommands;
 use crate::config::{CageConfig, CageConfigError};
 use crate::encrypt::{self, encrypt};
+#[cfg(feature = "internal_dependency")]
 use rust_crypto::EvervaultCryptoError;
 use thiserror::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,13 @@ pub mod config;
 pub mod delete;
 pub mod deploy;
 pub mod describe;
+#[cfg(feature = "internal_dependency")]
 pub mod dev;
 pub mod docker;
 pub mod enclave;
+#[cfg(feature = "internal_dependency")]
 pub mod encrypt;
+#[cfg(feature = "internal_dependency")]
 pub mod env;
 pub mod progress;
 pub mod restart;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,11 @@ use env_logger::{Builder, Env};
 #[cfg(not(target_os = "windows"))]
 use ev_cage::cli::attest;
 use ev_cage::cli::{
-    build, cert, delete, deploy, describe, dev, encrypt, env, init, list, logs, restart, scale,
-    update, Command,
+    build, cert, delete, deploy, describe, init, list, logs, restart, scale, update, Command,
 };
+
+#[cfg(feature = "internal_dependency")]
+use ev_cage::cli::{dev, encrypt, env};
 use human_panic::setup_panic;
 use log::Record;
 use std::io::Write;
@@ -51,6 +53,7 @@ async fn main() {
         Command::Delete(delete_args) => delete::run(delete_args).await,
         Command::Deploy(deploy_args) => deploy::run(deploy_args).await,
         Command::Describe(describe_args) => describe::run(describe_args).await,
+        #[cfg(feature = "internal_dependency")]
         Command::Dev(dev_args) => dev::run(dev_args).await,
         Command::Init(init_args) => init::run(init_args).await,
         Command::List(list_args) => list::run(list_args).await,
@@ -58,7 +61,9 @@ async fn main() {
         Command::Update(update_args) => update::run(update_args).await,
         #[cfg(not(target_os = "windows"))]
         Command::Attest(attest_args) => attest::run(attest_args).await,
+        #[cfg(feature = "internal_dependency")]
         Command::Env(env_args) => env::run(env_args).await,
+        #[cfg(feature = "internal_dependency")]
         Command::Encrypt(env_args) => encrypt::run(env_args).await,
         Command::Restart(restart_args) => restart::run(restart_args).await,
         Command::Scale(scale_args) => scale::run(scale_args).await,


### PR DESCRIPTION
# Why
Rust crypto is used for the local api, encrypting strings including env vars.
We plan to open source the library but in the meantime feature flag it to allow local builds for users outside of evervault 

# How
Feature flags modules that rely on library
