### PR TITLE
Fix: update CLI release flow to correct paths, and generate installers with the right url

### DIFF
--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           script: |
             const [ref,tag,version] = context.ref.split('/');
+            if (version[0] === 'v') {
+              return version.slice(1).split('.')[0];
+            }
             return version.split('.')[0];
           result-encoding: string
 
@@ -280,16 +283,16 @@ jobs:
 
       - name: Upload MacOS CLI to S3
         run: |
-          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.full_version }}/${{ needs.get-version.outputs.full_version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.major_version }}/${{ needs.get-version.outputs.full_version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
 
       - name: Upload Ubuntu CLI to S3
         run: |
-          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.full_version }}/${{ needs.get-version.outputs.full_version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.major_version }}/${{ needs.get-version.outputs.full_version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
 
       - uses: actions/checkout@v2
       - name: Update install script in S3
         run: |
-          sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.full_version }}
+          sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.full_version }} ${{ needs.get-version.outputs.major_version }}
           sh ./scripts/update-versions.sh ${{ needs.get-version.outputs.full_version }}
           aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.major_version }}/${{needs.get-version.outputs.full_version}}/install
           aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/install

--- a/scripts/generate-installer.sh
+++ b/scripts/generate-installer.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 pattern="s/{{version}}/$1/"
+major_pattern="s/{{major}}/$2/"
 
 sed -e "$pattern" ./scripts/install.template > ./scripts/install
+sed -e "$major_pattern" ./scripts/install > ./scripts/install
 
 sed -e "$pattern" ./scripts/version.template > ./scripts/version

--- a/scripts/install.template
+++ b/scripts/install.template
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -eu
 
-EV_DOWNLOAD_Darwin_universal="https://cage-build-assets.evervault.com/cli/{{version}}/x86_64-apple-darwin/ev-cage.tar.gz"
-EV_DOWNLOAD_Windows_x86_64="https://cage-build-assets.evervault.com/cli/{{version}}/x86_64-pc-windows-msvc/ev-cage.tar.gz"
-EV_DOWNLOAD_Linux_x86_64="https://cage-build-assets.evervault.com/cli/{{version}}/x86_64-unknown-linux-musl/ev-cage.tar.gz"
+EV_DOWNLOAD_Darwin_universal="https://cage-build-assets.evervault.com/cli/{{major}}/{{version}}/x86_64-apple-darwin/ev-cage.tar.gz"
+EV_DOWNLOAD_Windows_x86_64="https://cage-build-assets.evervault.com/cli/{{major}}/{{version}}/x86_64-pc-windows-msvc/ev-cage.tar.gz"
+EV_DOWNLOAD_Linux_x86_64="https://cage-build-assets.evervault.com/cli/{{major}}/{{version}}/x86_64-unknown-linux-musl/ev-cage.tar.gz"
 
 VERSION="{{version}}"
 PLATFORM=`uname -s`


### PR DESCRIPTION
# Why
New release flow had some issues 
- the binaries were uploaded to the wrong path 
- the installers path didn't include the major version
- the major version had a leading `v`

# How
- Update the CI workflow to upload to `major/full-version`
- Update the installer path to include the major version
- Strip the leading v if present in the GH script