### PR TITLE
use su inline when execing user entrypoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "rust-crypto"
 version = "0.1.24"
-source = "sparse+https://dl.cloudsmith.io/tREKUrB8e35qy9O7/evervault/rust-libraries/cargo/"
+source = "sparse+https://cargo.cloudsmith.io/evervault/rust-libraries/"
 checksum = "cee2de111fd94746e67580b021e64cc05bf776b4c2f776d5c965887a20768011"
 dependencies = [
  "base-x",


### PR DESCRIPTION
# Why
Performing an su at the start of the user entrypoint script was resulting in errors due to there being no interactive shell. Moving it to the final line to exec the process will remove the need for a shell (as being run as root).

# How
Remove early su call, replace with `su <user> -c`
