### PR TITLE
Improve deployment polling logic (#62)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +843,12 @@ dependencies = [
  "quote",
  "syn 2.0.39",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "ecdsa"
@@ -949,6 +961,7 @@ dependencies = [
  "itertools",
  "log",
  "minus",
+ "mockall",
  "rcgen",
  "regex",
  "reqwest",
@@ -995,6 +1008,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1045,12 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
@@ -1634,6 +1662,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1727,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-bigint"
@@ -1988,6 +2049,36 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "primeorder"
@@ -2848,6 +2939,12 @@ checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ semver = "1.0.20"
 [dev-dependencies]
 tokio-test = "0.4.2"
 serial_test = "2.0.0"
+mockall = "0.11.4"
 
 [target.'cfg(unix)'.dependencies]
 aws-nitro-enclaves-nsm-api = { version = "0.2.1" }

--- a/src/api/cage.rs
+++ b/src/api/cage.rs
@@ -5,6 +5,9 @@ use super::AuthMode;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+use mockall::automock;
+
 #[derive(Clone)]
 pub struct CagesClient {
     inner: GenericApiClient,
@@ -29,14 +32,68 @@ impl ApiClient for CagesClient {
     }
 }
 
+#[async_trait::async_trait]
+#[cfg_attr(test, automock)]
+pub trait CageApi {
+    async fn create_cage(&self, cage_create_payload: CreateCageRequest) -> ApiResult<Cage>;
+    async fn create_cage_deployment_intent(
+        &self,
+        cage_uuid: &str,
+        payload: CreateCageDeploymentIntentRequest,
+    ) -> ApiResult<CreateCageDeploymentIntentResponse>;
+    async fn create_cage_signing_cert_ref(
+        &self,
+        payload: CreateCageSigningCertRefRequest,
+    ) -> ApiResult<CreateCageSigningCertRefResponse>;
+    async fn get_cages(&self) -> ApiResult<GetCagesResponse>;
+    async fn get_cage(&self, cage_uuid: &str) -> ApiResult<GetCageResponse>;
+    async fn get_app_keys(&self, team_uuid: &str, app_uuid: &str) -> ApiResult<GetKeysResponse>;
+    async fn add_env_var(&self, cage_uuid: String, payload: AddSecretRequest) -> ApiResult<()>;
+    async fn delete_env_var(&self, cage_uuid: String, name: String) -> ApiResult<()>;
+    async fn get_cage_env(&self, cage_uuid: String) -> ApiResult<CageEnv>;
+    async fn get_cage_deployment_by_uuid(
+        &self,
+        cage_uuid: &str,
+        deployment_uuid: &str,
+    ) -> ApiResult<GetCageDeploymentResponse>;
+    async fn get_signing_certs(&self) -> ApiResult<GetSigningCertsResponse>;
+    async fn update_cage_locked_signing_certs(
+        &self,
+        cage_uuid: &str,
+        payload: UpdateLockedCageSigningCertRequest,
+    ) -> ApiResult<Vec<CageToSigningCert>>;
+    async fn get_cage_locked_signing_certs(
+        &self,
+        cage_uuid: &str,
+    ) -> ApiResult<Vec<CageSigningCert>>;
+    async fn get_cage_cert_by_uuid(&self, cert_uuid: &str) -> ApiResult<CageSigningCert>;
+    async fn get_cage_logs(
+        &self,
+        cage_uuid: &str,
+        start_time: u128,
+        end_time: u128,
+    ) -> ApiResult<CageLogs>;
+    async fn delete_cage(&self, cage_uuid: &str) -> ApiResult<DeleteCageResponse>;
+    async fn restart_cage(&self, cage_uuid: &str) -> ApiResult<CageDeployment>;
+    async fn get_scaling_config(&self, cage_uuid: &str) -> ApiResult<CageScalingConfig>;
+    async fn update_scaling_config(
+        &self,
+        cage_uuid: &str,
+        update_scaling_config_request: UpdateCageScalingConfigRequest,
+    ) -> ApiResult<CageScalingConfig>;
+}
+
 impl CagesClient {
     pub fn new(auth_mode: AuthMode) -> Self {
         Self {
             inner: GenericApiClient::from(auth_mode),
         }
     }
+}
 
-    pub async fn create_cage(&self, cage_create_payload: CreateCageRequest) -> ApiResult<Cage> {
+#[async_trait::async_trait]
+impl CageApi for CagesClient {
+    async fn create_cage(&self, cage_create_payload: CreateCageRequest) -> ApiResult<Cage> {
         let create_cage_url = format!("{}/", self.base_url());
         self.post(&create_cage_url)
             .json(&cage_create_payload)
@@ -46,7 +103,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn create_cage_deployment_intent(
+    async fn create_cage_deployment_intent(
         &self,
         cage_uuid: &str,
         payload: CreateCageDeploymentIntentRequest,
@@ -60,7 +117,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn create_cage_signing_cert_ref(
+    async fn create_cage_signing_cert_ref(
         &self,
         payload: CreateCageSigningCertRefRequest,
     ) -> ApiResult<CreateCageSigningCertRefResponse> {
@@ -73,7 +130,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn get_cages(&self) -> ApiResult<GetCagesResponse> {
+    async fn get_cages(&self) -> ApiResult<GetCagesResponse> {
         let get_cages_url = format!("{}/", self.base_url());
         self.get(&get_cages_url)
             .send()
@@ -82,7 +139,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn get_cage(&self, cage_uuid: &str) -> ApiResult<GetCageResponse> {
+    async fn get_cage(&self, cage_uuid: &str) -> ApiResult<GetCageResponse> {
         let get_cage_url = format!("{}/{}", self.base_url(), cage_uuid);
         self.get(&get_cage_url)
             .send()
@@ -91,11 +148,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn get_app_keys(
-        &self,
-        team_uuid: &str,
-        app_uuid: &str,
-    ) -> ApiResult<GetKeysResponse> {
+    async fn get_app_keys(&self, team_uuid: &str, app_uuid: &str) -> ApiResult<GetKeysResponse> {
         let get_cage_url = format!("{}/{}/apps/{}", self.keys_url(), team_uuid, app_uuid);
         self.get(&get_cage_url)
             .send()
@@ -104,7 +157,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn add_env_var(&self, cage_uuid: String, payload: AddSecretRequest) -> ApiResult<()> {
+    async fn add_env_var(&self, cage_uuid: String, payload: AddSecretRequest) -> ApiResult<()> {
         let add_env_url = format!("{}/{}/secrets", self.base_url(), cage_uuid);
         self.put(&add_env_url)
             .json(&payload)
@@ -113,7 +166,7 @@ impl CagesClient {
             .handle_no_op_response()
     }
 
-    pub async fn delete_env_var(&self, cage_uuid: String, name: String) -> ApiResult<()> {
+    async fn delete_env_var(&self, cage_uuid: String, name: String) -> ApiResult<()> {
         let delete_env_url = format!("{}/{}/secrets/{}", self.base_url(), cage_uuid, name);
         self.delete(&delete_env_url)
             .send()
@@ -121,7 +174,7 @@ impl CagesClient {
             .handle_no_op_response()
     }
 
-    pub async fn get_cage_env(&self, cage_uuid: String) -> ApiResult<CageEnv> {
+    async fn get_cage_env(&self, cage_uuid: String) -> ApiResult<CageEnv> {
         let get_env_url = format!("{}/{}/secrets", self.base_url(), cage_uuid);
         self.get(&get_env_url)
             .send()
@@ -130,7 +183,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn get_cage_deployment_by_uuid(
+    async fn get_cage_deployment_by_uuid(
         &self,
         cage_uuid: &str,
         deployment_uuid: &str,
@@ -148,7 +201,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn get_signing_certs(&self) -> ApiResult<GetSigningCertsResponse> {
+    async fn get_signing_certs(&self) -> ApiResult<GetSigningCertsResponse> {
         let get_certs_url = format!("{}/signing/certs", self.base_url(),);
         self.get(&get_certs_url)
             .send()
@@ -157,7 +210,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn update_cage_locked_signing_certs(
+    async fn update_cage_locked_signing_certs(
         &self,
         cage_uuid: &str,
         payload: UpdateLockedCageSigningCertRequest,
@@ -171,7 +224,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn get_cage_locked_signing_certs(
+    async fn get_cage_locked_signing_certs(
         &self,
         cage_uuid: &str,
     ) -> ApiResult<Vec<CageSigningCert>> {
@@ -183,7 +236,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn get_cage_cert_by_uuid(&self, cert_uuid: &str) -> ApiResult<CageSigningCert> {
+    async fn get_cage_cert_by_uuid(&self, cert_uuid: &str) -> ApiResult<CageSigningCert> {
         let get_cert_url = format!("{}/signing/certs/{}", self.base_url(), cert_uuid);
         self.get(&get_cert_url)
             .send()
@@ -192,7 +245,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn get_cage_logs(
+    async fn get_cage_logs(
         &self,
         cage_uuid: &str,
         start_time: u128,
@@ -211,7 +264,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn delete_cage(&self, cage_uuid: &str) -> ApiResult<DeleteCageResponse> {
+    async fn delete_cage(&self, cage_uuid: &str) -> ApiResult<DeleteCageResponse> {
         let delete_cage_url = format!("{}/{}", self.base_url(), cage_uuid);
         self.delete(&delete_cage_url)
             .send()
@@ -220,7 +273,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn restart_cage(&self, cage_uuid: &str) -> ApiResult<CageDeployment> {
+    async fn restart_cage(&self, cage_uuid: &str) -> ApiResult<CageDeployment> {
         let patch_cage_url = format!("{}/{}", self.base_url(), cage_uuid);
         self.patch(&patch_cage_url)
             .send()
@@ -229,7 +282,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn get_scaling_config(&self, cage_uuid: &str) -> ApiResult<CageScalingConfig> {
+    async fn get_scaling_config(&self, cage_uuid: &str) -> ApiResult<CageScalingConfig> {
         let cage_scaling_url = format!("{}/{}/scale", self.base_url(), cage_uuid);
         self.get(&cage_scaling_url)
             .send()
@@ -238,7 +291,7 @@ impl CagesClient {
             .await
     }
 
-    pub async fn update_scaling_config(
+    async fn update_scaling_config(
         &self,
         cage_uuid: &str,
         update_scaling_config_request: UpdateCageScalingConfigRequest,
@@ -494,13 +547,13 @@ impl Cage {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CageDeployment {
-    uuid: String,
-    cage_uuid: String,
-    version_uuid: String,
-    signing_cert_uuid: String,
-    debug_mode: bool,
-    started_at: Option<String>,
-    completed_at: Option<String>,
+    pub uuid: String,
+    pub cage_uuid: String,
+    pub version_uuid: String,
+    pub signing_cert_uuid: String,
+    pub debug_mode: bool,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
 }
 
 impl CageDeployment {
@@ -529,26 +582,26 @@ pub enum BuildStatus {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CageVersion {
-    uuid: String,
-    version: u16,
-    control_plane_img_url: Option<String>,
-    control_plane_version: Option<String>,
-    data_plane_version: Option<String>,
-    build_status: BuildStatus,
-    failure_reason: Option<String>,
-    started_at: Option<String>,
-    healthcheck: Option<String>,
+    pub uuid: String,
+    pub version: u16,
+    pub control_plane_img_url: Option<String>,
+    pub control_plane_version: Option<String>,
+    pub data_plane_version: Option<String>,
+    pub build_status: BuildStatus,
+    pub failure_reason: Option<String>,
+    pub started_at: Option<String>,
+    pub healthcheck: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd)]
 #[serde(rename_all = "camelCase")]
 pub struct CageSigningCert {
-    name: Option<String>,
-    uuid: String,
-    app_uuid: String,
-    cert_hash: String,
-    not_before: Option<String>,
-    not_after: Option<String>,
+    pub name: Option<String>,
+    pub uuid: String,
+    pub app_uuid: String,
+    pub cert_hash: String,
+    pub not_before: Option<String>,
+    pub not_after: Option<String>,
 }
 
 impl CageSigningCert {
@@ -607,17 +660,17 @@ pub enum DeployStatus {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CageRegionalDeployment {
-    uuid: String,
-    deployment_uuid: String,
-    deployment_order: u16,
-    region: String,
-    failure_reason: Option<String>,
-    deploy_status: DeployStatus,
+    pub uuid: String,
+    pub deployment_uuid: String,
+    pub deployment_order: u16,
+    pub region: String,
+    pub failure_reason: Option<String>,
+    pub deploy_status: DeployStatus,
     // started_at should be required, but is being returned as null sometimes
     // should revert this to just String after API fix
-    started_at: Option<String>,
-    completed_at: Option<String>,
-    detailed_status: Option<String>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub detailed_status: Option<String>,
 }
 
 impl CageRegionalDeployment {
@@ -654,18 +707,18 @@ impl GetCagesResponse {
 #[serde(rename_all = "camelCase")]
 pub struct DeploymentsForGetCage {
     #[serde(flatten)]
-    deployment: CageDeployment,
+    pub deployment: CageDeployment,
     #[serde(rename = "teeCageVersion")]
-    version: CageVersion,
+    pub version: CageVersion,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetCageResponse {
     #[serde(flatten)]
-    cage: Cage,
+    pub cage: Cage,
     #[serde(rename = "teeCageDeployments")]
-    deployments: Vec<DeploymentsForGetCage>,
+    pub deployments: Vec<DeploymentsForGetCage>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -690,15 +743,15 @@ impl GetCageResponse {
 #[serde(rename_all = "camelCase")]
 pub struct GetCageDeploymentResponse {
     #[serde(flatten)]
-    deployment: CageDeployment,
-    tee_cage_version: CageVersion,
-    tee_cage_signing_cert: CageSigningCert,
-    tee_cage_regional_deployments: Vec<CageRegionalDeployment>,
+    pub deployment: CageDeployment,
+    pub tee_cage_version: CageVersion,
+    pub tee_cage_signing_cert: CageSigningCert,
+    pub tee_cage_regional_deployments: Vec<CageRegionalDeployment>,
 }
 
 impl GetCageDeploymentResponse {
     pub fn is_built(&self) -> bool {
-        self.tee_cage_version.build_status == BuildStatus::Ready
+        matches!(self.tee_cage_version.build_status, BuildStatus::Ready)
     }
 
     pub fn is_finished(&self) -> bool {
@@ -706,16 +759,22 @@ impl GetCageDeploymentResponse {
     }
 
     //TODO: Handle multi region deployment failures
-    pub fn is_failed(&self) -> Option<bool> {
-        self.tee_cage_regional_deployments
-            .first()
-            .map(|depl| depl.is_failed())
+    pub fn is_failed(&self) -> bool {
+        let build_failed = matches!(self.tee_cage_version.build_status, BuildStatus::Failed);
+        build_failed
+            || self
+                .tee_cage_regional_deployments
+                .first()
+                .map(|depl| depl.is_failed())
+                .unwrap_or_default()
     }
 
     pub fn get_failure_reason(&self) -> Option<String> {
-        self.tee_cage_regional_deployments
-            .first()
-            .map(|depl| depl.get_failure_reason())
+        self.tee_cage_version.failure_reason.clone().or_else(|| {
+            self.tee_cage_regional_deployments
+                .first()
+                .map(|depl| depl.get_failure_reason())
+        })
     }
 
     pub fn get_detailed_status(&self) -> Option<String> {
@@ -881,7 +940,7 @@ mod test {
         assert!(deployment_with_empty_regional
             .get_failure_reason()
             .is_none());
-        assert!(deployment_with_empty_regional.is_failed().is_none());
+        assert_eq!(deployment_with_empty_regional.is_failed(), false);
     }
 
     #[test]
@@ -909,7 +968,7 @@ mod test {
             }],
         };
 
-        assert_eq!(deployment_with_regional.is_failed(), Some(true));
+        assert_eq!(deployment_with_regional.is_failed(), true);
         assert_eq!(
             deployment_with_regional.get_failure_reason(),
             Some(failure_reason)

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -244,7 +244,7 @@ impl std::fmt::Debug for ApiError {
 
 impl std::error::Error for ApiError {}
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case")]
 pub struct ApiErrorDetails {
     pub status_code: Option<u16>,

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -11,7 +11,7 @@ use x509_parser::parse_x509_certificate;
 use x509_parser::prelude::{parse_x509_pem, X509Certificate};
 
 use crate::api::cage::{
-    CageSigningCert, CreateCageSigningCertRefRequest, CreateCageSigningCertRefResponse,
+    CageApi, CageSigningCert, CreateCageSigningCertRefRequest, CreateCageSigningCertRefResponse,
     UpdateLockedCageSigningCertRequest,
 };
 use crate::api::{self, AuthMode};

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -1,5 +1,5 @@
 use crate::api::client::ApiErrorKind;
-use crate::api::{self, assets::AssetsClient, AuthMode};
+use crate::api::{self, assets::AssetsClient, cage::CageApi, AuthMode};
 use crate::build::build_enclave_image_file;
 use crate::common::prepare_build_args;
 use crate::docker::command::get_source_date_epoch;

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,6 +1,9 @@
 use crate::api;
 use crate::api::cage::CreateCageRequest;
-use crate::api::{cage::Cage, AuthMode};
+use crate::api::{
+    cage::{Cage, CageApi},
+    AuthMode,
+};
 use crate::common::CliError;
 use crate::config::{default_dockerfile, CageConfig, EgressSettings, ScalingSettings, SigningInfo};
 use crate::get_api_key;

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,4 +1,4 @@
-use crate::api::AuthMode;
+use crate::api::{cage::CageApi, AuthMode};
 use crate::common::CliError;
 use crate::config::{read_and_validate_config, BuildTimeConfig};
 use crate::version::check_version;

--- a/src/cli/scale.rs
+++ b/src/cli/scale.rs
@@ -1,7 +1,10 @@
 use crate::config::{self, ScalingSettings};
 use crate::version::check_version;
 use crate::{
-    api::{cage::CagesClient, AuthMode},
+    api::{
+        cage::{CageApi, CagesClient},
+        AuthMode,
+    },
     common::CliError,
     config::CageConfig,
     get_api_key,

--- a/src/delete/mod.rs
+++ b/src/delete/mod.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use crate::api;
-use crate::api::cage::CagesClient;
+use crate::api::cage::CageApi;
 use crate::api::AuthMode;
 use crate::progress::{get_tracker, poll_fn_and_report_status, ProgressLogger, StatusReport};
 mod error;
@@ -29,35 +31,124 @@ pub async fn delete_cage(
     if !background {
         let progress_bar = get_tracker("Deleting Cage...", None);
 
-        watch_deletion(cage_api, deleted_cage.uuid(), progress_bar).await;
+        watch_deletion(cage_api, deleted_cage.uuid(), progress_bar).await?;
     }
     Ok(())
 }
 
-async fn watch_deletion(cage_api: CagesClient, cage_uuid: &str, progress_bar: impl ProgressLogger) {
-    async fn check_delete_status(
-        cage_api: CagesClient,
+async fn watch_deletion<T: CageApi>(
+    cage_api: T,
+    cage_uuid: &str,
+    progress_bar: impl ProgressLogger,
+) -> Result<(), DeleteError> {
+    async fn check_delete_status<T: CageApi>(
+        cage_api: Arc<T>,
         args: Vec<String>,
     ) -> Result<StatusReport, DeleteError> {
         let cage_uuid = args.get(0).unwrap();
-        match cage_api.get_cage(cage_uuid).await {
-            Ok(cage_response) if cage_response.is_deleted() => {
-                Ok(StatusReport::Complete("Cage deleted!".to_string()))
-            }
-            Ok(_) => Ok(StatusReport::NoOp),
+        let cage_response = match cage_api.get_cage(cage_uuid).await {
+            Ok(response) => response,
             Err(e) => {
+                println!("error in status check");
                 log::error!("Unable to retrieve deletion status. Error: {:?}", e);
-                Ok(StatusReport::Failed)
+                return Err(e.into());
             }
+        };
+        if cage_response.is_deleted() {
+            Ok(StatusReport::Complete("Cage deleted!".to_string()))
+        } else {
+            Ok(StatusReport::NoOp)
         }
     }
 
     let check_delete_args = vec![cage_uuid.to_string()];
-    let _ = poll_fn_and_report_status(
-        cage_api,
+    poll_fn_and_report_status(
+        Arc::new(cage_api),
         check_delete_args,
         check_delete_status,
         progress_bar,
     )
-    .await;
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::api::cage::{CageState, DeleteCageResponse, MockCageApi};
+    use crate::api::client::ApiError;
+    use crate::progress::NonTty;
+    use crate::test_utils::build_get_cage_response;
+
+    #[tokio::test]
+    async fn test_watch_deletion_with_healthy_responses() {
+        let mut mock_api = MockCageApi::new();
+
+        let mut responses = vec![
+            build_get_cage_response(CageState::Pending, vec![]),
+            build_get_cage_response(CageState::Deleting, vec![]),
+            build_get_cage_response(CageState::Deleted, vec![]),
+        ]
+        .into_iter();
+
+        mock_api
+            .expect_get_cage()
+            .times(3)
+            .returning(move |_| Box::pin(std::future::ready(Ok(responses.next().unwrap()))));
+        let result = watch_deletion(mock_api, "abc".into(), NonTty).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_watch_deletion_with_errors() {
+        let mut mock_api = MockCageApi::new();
+
+        let mut responses = vec![
+            ApiError::new(api::client::ApiErrorKind::Internal),
+            ApiError::new(api::client::ApiErrorKind::Internal),
+            ApiError::new(api::client::ApiErrorKind::Internal),
+            ApiError::new(api::client::ApiErrorKind::Internal),
+            ApiError::new(api::client::ApiErrorKind::Internal),
+        ]
+        .into_iter();
+
+        mock_api
+            .expect_get_cage()
+            .times(5)
+            .returning(move |_| Box::pin(std::future::ready(Err(responses.next().unwrap()))));
+        let result = watch_deletion(mock_api, "abc".into(), NonTty).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_cage_performs_polling_cage_status() {
+        let mut mock_api = MockCageApi::new();
+        mock_api.expect_delete_cage().returning(move |_| {
+            Box::pin(std::future::ready(Ok(DeleteCageResponse {
+                uuid: "abc".into(),
+                name: "def".into(),
+                team_uuid: "team".into(),
+                app_uuid: "app".into(),
+                domain: "cage.com".into(),
+                state: CageState::Deleting,
+                created_at: "".into(),
+                updated_at: "".into(),
+            })))
+        });
+
+        let mut responses = vec![
+            Ok(build_get_cage_response(CageState::Deleting, vec![])),
+            Ok(build_get_cage_response(CageState::Deleting, vec![])),
+            Err(ApiError::new(api::client::ApiErrorKind::Internal)),
+            Ok(build_get_cage_response(CageState::Deleted, vec![])),
+        ]
+        .into_iter();
+
+        mock_api
+            .expect_get_cage()
+            .times(4)
+            .returning(move |_| Box::pin(std::future::ready(responses.next().unwrap())));
+        let result = watch_deletion(mock_api, "abc".into(), NonTty).await;
+        assert!(result.is_ok());
+    }
 }

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -1,11 +1,12 @@
 use crate::api;
-use crate::api::{cage::CagesClient, cage::CreateCageDeploymentIntentRequest};
+use crate::api::{cage::CageApi, cage::CreateCageDeploymentIntentRequest};
 use crate::common::{resolve_output_path, OutputPath};
 use crate::config::ValidatedCageBuildConfig;
 use crate::describe::describe_eif;
 use crate::enclave::{EIFMeasurements, ENCLAVE_FILENAME};
 use crate::progress::{get_tracker, poll_fn_and_report_status, ProgressLogger, StatusReport};
 use std::io::Write;
+use std::sync::Arc;
 mod error;
 use crate::docker::command::get_git_hash;
 use crate::docker::command::get_source_date_epoch;
@@ -21,9 +22,9 @@ use tokio_util::codec::{BytesCodec, FramedRead};
 const ENCLAVE_ZIP_FILENAME: &str = "enclave.zip";
 pub const DEPLOY_WATCH_TIMEOUT_SECONDS: u64 = 1200; //15 minutes
 
-pub async fn deploy_eif(
+pub async fn deploy_eif<T: CageApi + Clone>(
     validated_config: &ValidatedCageBuildConfig,
-    cage_api: CagesClient,
+    cage_api: T,
     output_path: OutputPath,
     eif_measurements: &EIFMeasurements,
     data_plane_version: String,
@@ -75,20 +76,24 @@ pub async fn deploy_eif(
     let progress_bar_for_build =
         get_tracker("Building Cage Docker Image on Evervault Infra...", None);
 
-    watch_build(
+    let build_complete = watch_build(
         cage_api.clone(),
         deployment_intent.cage_uuid(),
         deployment_intent.deployment_uuid(),
         progress_bar_for_build,
     )
-    .await;
+    .await?;
+
+    if !build_complete {
+        return Err(DeployError::DeploymentError);
+    }
 
     let progress_bar_for_deploy = get_tracker(
         "Deploying Cage into a Trusted Execution Environment...",
         None,
     );
 
-    timed_operation(
+    let deployment_complete = timed_operation(
         "Cage Deployment",
         DEPLOY_WATCH_TIMEOUT_SECONDS,
         watch_deployment(
@@ -98,84 +103,93 @@ pub async fn deploy_eif(
             progress_bar_for_deploy,
         ),
     )
-    .await?
-}
+    .await??;
 
-async fn watch_build(
-    cage_api: CagesClient,
-    cage_uuid: &str,
-    deployment_uuid: &str,
-    progress_bar: impl ProgressLogger,
-) {
-    async fn check_build_status(
-        cage_api: CagesClient,
-        args: Vec<String>,
-    ) -> Result<StatusReport, DeployError> {
-        let cage_uuid = args.get(0).unwrap();
-        let deployment_uuid = args.get(1).unwrap();
-        match cage_api
-            .get_cage_deployment_by_uuid(cage_uuid, deployment_uuid)
-            .await
-        {
-            Ok(deployment_response) if deployment_response.is_built() => Ok(
-                StatusReport::complete("Cage built on Evervault!".to_string()),
-            ),
-            Ok(_) => Ok(StatusReport::no_op()),
-            Err(e) => {
-                log::error!("Unable to retrieve build status. Error: {:?}", e);
-                Ok(StatusReport::Failed)
-            }
-        }
+    if !deployment_complete {
+        return Err(DeployError::DeploymentError);
     }
-    let get_deployment_args = vec![cage_uuid.to_string(), deployment_uuid.to_string()];
-    let _ = poll_fn_and_report_status(
-        cage_api,
-        get_deployment_args,
-        check_build_status,
-        progress_bar,
-    )
-    .await;
+
+    Ok(())
 }
 
-pub async fn watch_deployment(
-    cage_api: CagesClient,
+async fn watch_build<T: CageApi>(
+    cage_api: T,
     cage_uuid: &str,
     deployment_uuid: &str,
     progress_bar: impl ProgressLogger,
-) -> Result<(), DeployError> {
-    async fn check_deployment_status(
-        cage_api: CagesClient,
+) -> Result<bool, DeployError> {
+    async fn check_build_status<T: CageApi>(
+        cage_api: Arc<T>,
         args: Vec<String>,
     ) -> Result<StatusReport, DeployError> {
         let cage_uuid = args.get(0).unwrap();
         let deployment_uuid = args.get(1).unwrap();
-        match cage_api
+        let deployment_response = cage_api
             .get_cage_deployment_by_uuid(cage_uuid, deployment_uuid)
-            .await
-        {
-            Ok(deployment_response) if deployment_response.is_finished() => {
-                Ok(StatusReport::complete("Cage deployed!".to_string()))
-            }
-            Ok(deployment_response) if deployment_response.is_failed().unwrap_or(false) => {
-                if let Some(reason) = deployment_response.get_failure_reason() {
-                    log::error!("{reason}");
-                }
-                Err(DeployError::DeploymentError)
-            }
-            Ok(deployment_response) => {
-                let status_report = match deployment_response.get_detailed_status() {
-                    Some(status) => StatusReport::update(status),
-                    None => StatusReport::NoOp,
-                };
-                Ok(status_report)
-            }
-            Err(_) => Ok(StatusReport::Failed),
+            .await?;
+        if deployment_response.is_built() {
+            Ok(StatusReport::complete(
+                "Cage built on Evervault!".to_string(),
+            ))
+        } else if deployment_response.is_failed() {
+            let failure_msg = deployment_response
+                .get_failure_reason()
+                .unwrap_or_else(|| "An unknown error occurred".into());
+            Ok(StatusReport::Failed(format!(
+                "Cage build failed - {failure_msg}"
+            )))
+        } else {
+            Ok(StatusReport::no_op())
         }
     }
 
     let get_deployment_args = vec![cage_uuid.to_string(), deployment_uuid.to_string()];
     poll_fn_and_report_status(
-        cage_api,
+        Arc::new(cage_api),
+        get_deployment_args,
+        check_build_status,
+        progress_bar,
+    )
+    .await
+}
+
+pub async fn watch_deployment<T: CageApi>(
+    cage_api: T,
+    cage_uuid: &str,
+    deployment_uuid: &str,
+    progress_bar: impl ProgressLogger,
+) -> Result<bool, DeployError> {
+    async fn check_deployment_status<T: CageApi>(
+        cage_api: Arc<T>,
+        args: Vec<String>,
+    ) -> Result<StatusReport, DeployError> {
+        let cage_uuid = args.get(0).unwrap();
+        let deployment_uuid = args.get(1).unwrap();
+        let deployment_response = cage_api
+            .get_cage_deployment_by_uuid(cage_uuid, deployment_uuid)
+            .await?;
+
+        if deployment_response.is_finished() {
+            Ok(StatusReport::complete("Cage deployed!".to_string()))
+        } else if deployment_response.is_failed() {
+            let failure_msg = deployment_response
+                .get_failure_reason()
+                .unwrap_or_else(|| "An unknown error occurred".into());
+            Ok(StatusReport::Failed(format!(
+                "Cage deployment failed - {failure_msg}"
+            )))
+        } else {
+            let status_report = match deployment_response.get_detailed_status() {
+                Some(status) => StatusReport::update(status),
+                None => StatusReport::NoOp,
+            };
+            Ok(status_report)
+        }
+    }
+
+    let get_deployment_args = vec![cage_uuid.to_string(), deployment_uuid.to_string()];
+    poll_fn_and_report_status(
+        Arc::new(cage_api),
         get_deployment_args,
         check_deployment_status,
         progress_bar,
@@ -265,7 +279,9 @@ pub async fn timed_operation<T: std::future::Future>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::cage::MockCageApi;
     use crate::enclave::PCRs;
+    use crate::progress::NonTty;
     use crate::test_utils;
     use std::time::Duration;
 
@@ -335,5 +351,153 @@ mod tests {
         };
 
         assert_eq!(correct_result, true);
+    }
+
+    #[tokio::test]
+    async fn test_watch_build() {
+        let mut mock_api = MockCageApi::new();
+        let start_time = Some(format!("{:?}", std::time::SystemTime::now()));
+        let mut responses = vec![
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Building,
+                api::cage::DeployStatus::Pending,
+                start_time.clone(),
+                None,
+            ),
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Building,
+                api::cage::DeployStatus::Pending,
+                start_time.clone(),
+                None,
+            ),
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Ready,
+                api::cage::DeployStatus::Pending,
+                start_time,
+                None,
+            ),
+        ]
+        .into_iter();
+
+        mock_api
+            .expect_get_cage_deployment_by_uuid()
+            .times(3)
+            .returning(move |_, _| Box::pin(std::future::ready(Ok(responses.next().unwrap()))));
+
+        let result = watch_build(mock_api, "".into(), "".into(), NonTty)
+            .await
+            .unwrap();
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn test_watch_failed_build() {
+        let mut mock_api = MockCageApi::new();
+        let start_time = Some(format!("{:?}", std::time::SystemTime::now()));
+        let mut responses = vec![
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Building,
+                api::cage::DeployStatus::Pending,
+                start_time.clone(),
+                None,
+            ),
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Building,
+                api::cage::DeployStatus::Pending,
+                start_time.clone(),
+                None,
+            ),
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Failed,
+                api::cage::DeployStatus::Pending,
+                start_time,
+                None,
+            ),
+        ]
+        .into_iter();
+
+        mock_api
+            .expect_get_cage_deployment_by_uuid()
+            .times(3)
+            .returning(move |_, _| Box::pin(std::future::ready(Ok(responses.next().unwrap()))));
+
+        let result = watch_build(mock_api, "".into(), "".into(), NonTty)
+            .await
+            .unwrap();
+        assert_eq!(result, false);
+    }
+
+    #[tokio::test]
+    async fn test_watch_deploy() {
+        let mut mock_api = MockCageApi::new();
+        let start_time = Some(format!("{:?}", std::time::SystemTime::now()));
+        let mut responses = vec![
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Ready,
+                api::cage::DeployStatus::Pending,
+                start_time.clone(),
+                None,
+            ),
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Ready,
+                api::cage::DeployStatus::Deploying,
+                start_time.clone(),
+                None,
+            ),
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Ready,
+                api::cage::DeployStatus::Ready,
+                start_time,
+                Some("".into()),
+            ),
+        ]
+        .into_iter();
+
+        mock_api
+            .expect_get_cage_deployment_by_uuid()
+            .times(3)
+            .returning(move |_, _| Box::pin(std::future::ready(Ok(responses.next().unwrap()))));
+
+        let result = watch_deployment(mock_api, "".into(), "".into(), NonTty)
+            .await
+            .unwrap();
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn test_watch_failed_deploy() {
+        let mut mock_api = MockCageApi::new();
+        let start_time = Some(format!("{:?}", std::time::SystemTime::now()));
+        let mut responses = vec![
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Ready,
+                api::cage::DeployStatus::Pending,
+                start_time.clone(),
+                None,
+            ),
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Ready,
+                api::cage::DeployStatus::Deploying,
+                start_time.clone(),
+                None,
+            ),
+            test_utils::build_get_cage_deployment(
+                api::cage::BuildStatus::Ready,
+                api::cage::DeployStatus::Failed,
+                start_time,
+                None,
+            ),
+        ]
+        .into_iter();
+
+        mock_api
+            .expect_get_cage_deployment_by_uuid()
+            .times(3)
+            .returning(move |_, _| Box::pin(std::future::ready(Ok(responses.next().unwrap()))));
+
+        let result = watch_deployment(mock_api, "".into(), "".into(), NonTty)
+            .await
+            .unwrap();
+        assert_eq!(result, false);
     }
 }

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -1,6 +1,9 @@
 use crate::config::CageConfigError;
 use crate::{
-    api::{cage::CagesClient, AuthMode},
+    api::{
+        cage::{CageApi, CagesClient},
+        AuthMode,
+    },
     cli::encrypt::CurveName,
 };
 use rust_crypto::{

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,4 +1,4 @@
-use crate::api::cage::{AddSecretRequest, CageEnv, CagesClient};
+use crate::api::cage::{AddSecretRequest, CageApi, CageEnv, CagesClient};
 use crate::cli::env::EnvCommands;
 use crate::config::{CageConfig, CageConfigError};
 use crate::encrypt::{self, encrypt};

--- a/src/logs/mod.rs
+++ b/src/logs/mod.rs
@@ -2,7 +2,10 @@ use chrono::TimeZone;
 use std::fmt::Write;
 use thiserror::Error;
 
-use crate::{api::cage::CagesClient, common::CliError};
+use crate::{
+    api::cage::{CageApi, CagesClient},
+    common::CliError,
+};
 
 #[derive(Debug, Error)]
 pub enum LogsError {

--- a/src/restart/mod.rs
+++ b/src/restart/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::cage::{CageDeployment, CagesClient},
+    api::cage::{CageApi, CageDeployment, CagesClient},
     common::CliError,
 };
 use thiserror::Error;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,4 +1,8 @@
 use crate::api::assets::AssetsClient;
+use crate::api::cage::{
+    BuildStatus, Cage, CageDeployment, CageRegionalDeployment, CageSigningCert, CageState,
+    CageVersion, DeployStatus, DeploymentsForGetCage, GetCageDeploymentResponse, GetCageResponse,
+};
 use crate::build::build_enclave_image_file;
 use crate::build::error::BuildError;
 use crate::common::OutputPath;
@@ -39,4 +43,72 @@ fn get_test_build_args() -> ValidatedCageBuildConfig {
     let (_cage_config, validated_config) = read_and_validate_config("./test.cage.toml", &())
         .expect("Testing config failed to validate");
     validated_config
+}
+
+pub fn build_get_cage_response(
+    state: CageState,
+    deployments: Vec<DeploymentsForGetCage>,
+) -> GetCageResponse {
+    GetCageResponse {
+        cage: Cage {
+            uuid: "abc".into(),
+            name: "def".into(),
+            team_uuid: "team_123".into(),
+            app_uuid: "app_456".into(),
+            domain: "cage.com".into(),
+            state,
+            created_at: "".into(),
+            updated_at: "".into(),
+        },
+        deployments,
+    }
+}
+
+pub fn build_get_cage_deployment(
+    build_status: BuildStatus,
+    deploy_status: DeployStatus,
+    started_at: Option<String>,
+    completed_at: Option<String>,
+) -> GetCageDeploymentResponse {
+    GetCageDeploymentResponse {
+        deployment: CageDeployment {
+            uuid: "".into(),
+            cage_uuid: "".into(),
+            version_uuid: "".into(),
+            signing_cert_uuid: "".into(),
+            debug_mode: true,
+            started_at: started_at.clone(),
+            completed_at: completed_at.clone(),
+        },
+        tee_cage_version: CageVersion {
+            uuid: "".into(),
+            version: 0,
+            control_plane_img_url: Some("".into()),
+            control_plane_version: Some("".into()),
+            data_plane_version: None,
+            build_status,
+            failure_reason: None,
+            started_at: started_at.clone(),
+            healthcheck: None,
+        },
+        tee_cage_signing_cert: CageSigningCert {
+            name: Some("".into()),
+            uuid: "".into(),
+            app_uuid: "".into(),
+            cert_hash: "".into(),
+            not_before: None,
+            not_after: None,
+        },
+        tee_cage_regional_deployments: vec![CageRegionalDeployment {
+            uuid: "".into(),
+            deployment_uuid: "".into(),
+            deployment_order: 0,
+            region: "".into(),
+            failure_reason: None,
+            deploy_status,
+            started_at,
+            completed_at,
+            detailed_status: Some("".into()),
+        }],
+    }
 }


### PR DESCRIPTION
# Why
Polling logic for deployments doesn't handle transient errors/job failures correctly. Update corrects this, making job failures exit immediately with an error log, and transient errors outputting an error log and continuing.

# How
Cherry pick commit with polling improvements to release/v0
