### PR TITLE
Publish staging CLI on push

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,242 @@
+name: "Build and publish CLI"
+on:
+  workflow_call:
+    inputs:
+      stage:
+        required: true
+        default: 'staging'
+        type: string
+      major-version:
+        required: true
+        type: string
+      full-version:
+        required: true
+        type: string 
+      ev-domain:
+        required: true
+        type: string   
+    secrets:    
+      aws-cloudfront-distribution-id:
+        required: true
+      aws-access-key-id:
+        required: true
+      aws-secret-access-key: 
+        required: true
+      evervault-rust-lib-index:
+        required: true
+      evervault-rust-lib-token: 
+        required: true
+
+env:
+  RUST_BACKTRACE: 1
+  WINDOWS_TARGET: x86_64-pc-windows-msvc
+  MACOS_TARGET: x86_64-apple-darwin
+  LINUX_TARGET: x86_64-unknown-linux-musl
+
+  # Directories to target during release
+  BIN_DIR: bin
+  RELEASE_DIR: release                               
+                
+jobs:
+  compile-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install musl-tools
+        run: sudo apt-get install musl-tools
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2023-09-13
+          override: true
+          target: ${{ env.LINUX_TARGET }}
+
+      - name: Download cached dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+            shared-key: "linux-cross-builds"
+
+      - name: Install cross
+        run: cargo install cross
+
+      - name: Inject Version
+        run: |
+          sh ./scripts/insert-cli-version.sh ${{ inputs.full-version }}
+
+      - name: Build and Compress cli
+        run: |
+          mkdir ${{ env.BIN_DIR }}
+          mkdir ${{ env.RELEASE_DIR }}
+          cross build --release --all-features --target ${{ env.LINUX_TARGET }} -Z registry-auth
+          mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz
+        env:
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.evervault-rust-lib-index }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.evervault-rust-lib-token }}
+          CARGO_HOME: ${{ github.workspace }}/.cargo
+
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: linux
+          path: ./${{ env.RELEASE_DIR }}
+
+  compile-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Inject Version
+        run: |
+          sh ./scripts/insert-cli-version.sh ${{ inputs.full-version }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2023-09-13
+          target: ${{ env.MACOS_TARGET }}
+          override: true
+      
+      - name: Download cached dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+            shared-key: "macos-cross-builds"
+
+      - name: Build CLI MacOs Target
+        run: |
+          cargo install cross
+          cross build --release --all-features --target ${{ env.MACOS_TARGET }} -Z registry-auth
+        env:
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.evervault-rust-lib-index }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.evervault-rust-lib-token }}
+
+      - name: Install 7z cli
+        run: brew install p7zip
+
+      - name: Setup directories
+        run: |
+          mkdir ${{ env.BIN_DIR }}
+          mkdir ${{ env.RELEASE_DIR }}
+
+      - name: Compress binary
+        run: |
+          mv target/${{env.MACOS_TARGET}}/release/ev-cage ${{ env.BIN_DIR }}/ev-cage
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ${{ env.RELEASE_DIR }}/ev-cage-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz
+
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: macos
+          path: ./${{ env.RELEASE_DIR }}
+
+  compile-windows:
+    runs-on: windows-latest
+    env:
+      VCPKGRS_DYNAMIC: 1
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        run: rustup update --no-self-update stable && rustup default stable
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2023-09-13
+          target: ${{ env.WINDOWS_TARGET }}
+          override: true
+
+      - name: Inject Version
+        run: |
+          sh ./scripts/insert-cli-version.sh ${{ inputs.full-version }}
+
+      - name: Download cached dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+            shared-key: "windows-cross-builds"
+
+      - name: Fetch dependencies
+        run: cargo fetch -Z registry-auth
+        env:
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.evervault-rust-lib-index }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.evervault-rust-lib-token }}
+
+      - name: Build CLI for Windows
+        run: |
+          cargo install cross
+          cross build --release --all-features --target ${{ env.WINDOWS_TARGET }} -Z registry-auth
+        env:
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.evervault-rust-lib-index }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.evervault-rust-lib-token }}
+
+      - name: Setup directories
+        shell: bash
+        run: |
+          mkdir ${{ env.BIN_DIR }}
+          mkdir ${{ env.RELEASE_DIR }}
+
+      - name: Compress
+        shell: bash
+        run: |
+          mv target/${{ env.WINDOWS_TARGET }}/release/ev-cage.exe ${{ env.BIN_DIR }}/ev-cage.exe
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.WINDOWS_TARGET }}-${{ inputs.full-version }}.tar.gz
+
+      - name: Upload as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows
+          path: ./${{ env.RELEASE_DIR }}
+
+          
+  upload-artifacts-to-s3:
+    needs: [ compile-ubuntu, compile-macos, compile-windows ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-region: us-east-1
+
+      - name: Download MacOS Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: macos
+
+      - name: Download Linux Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: linux
+
+      - name: Download Windows Artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: windows
+
+      - name: Upload Windows CLI to S3
+        run: |
+          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.full-version }}/${{ inputs.full-version}}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
+
+      - name: Upload MacOS CLI to S3
+        run: |
+          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.full-version }}/${{ inputs.full-version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+
+      - name: Upload Ubuntu CLI to S3
+        run: |
+          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
+
+      - uses: actions/checkout@v3
+      - name: Update install script in S3
+        run: |
+          sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }}
+          sh ./scripts/update-versions.sh ${{ inputs.full-version }}
+          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install
+          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/install
+          aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/version
+          aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/version
+          aws s3 cp scripts/versions s3://cage-build-assets-${{ inputs.stage }}/cli/versions
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/cli/install" "/cli/version" "/cli/versions"
+
+

--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -1,11 +1,7 @@
 on:
   push:
-    paths:
-      - src/**
-      - tests/**
-      - .github/workflows/lint-and-test-cli.yml
-      - Cargo.toml
-name: Lint and Test CLI
+    branches:
+      - main
 
 jobs:
   clippy_check_cli:
@@ -37,3 +33,29 @@ jobs:
         run: cargo clippy
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+
+  get-version:
+    needs: [clippy_check_cli]
+    runs-on: ubuntu-latest
+    outputs:
+      full_version: ${{ steps.get-full-version.outputs.full_version }}
+    steps:
+      - id: get-full-version
+        run: |
+          echo "using sha tag ${GITHUB_SHA::6}"
+          echo ::set-output name=full_version::1.0.0-${GITHUB_SHA::6}
+          
+  build-and-deploy:
+    needs: [get-version]
+    uses: ./.github/workflows/build-and-publish.yml
+    with:
+      stage: 'staging'
+      major-version: '1'
+      full-version: "${{ needs.get-version.outputs.full_version }}"
+      ev-domain: 'evervault.io'
+    secrets:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+        aws-cloudfront-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_STAGING }}
+        evervault-rust-lib-index: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+        evervault-rust-lib-token: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -39,161 +39,22 @@ jobs:
             return version.split('.')[0];
           result-encoding: string
 
-  compile-ubuntu:
-    runs-on: ubuntu-latest
-    needs: get-version
-    steps:
-      - uses: actions/checkout@v2
+  build-and-deploy:
+    uses: ./.github/workflows/build-and-publish.yml
+    with:
+      stage: 'production'
+      major-version:  ${{ needs.get-version.outputs.major_version }}
+      full-version: ${{ needs.get-version.outputs.full_version }}
+      ev-domain: 'evervault.com'
+    secrets:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-cloudfront-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+      evervault-rust-lib-index: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+      evervault-rust-lib-token: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 
-      - name: Install musl-tools
-        run: sudo apt-get install musl-tools
-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2023-09-13
-          override: true
-          target: ${{ env.LINUX_TARGET }}
-
-      - name: Download cached dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-            shared-key: "linux-cross-builds"
-
-      - name: Install cross
-        run: cargo install cross
-
-      - name: Inject Version
-        run: |
-          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.full_version }}
-
-      - name: Build and Compress cli
-        run: |
-          mkdir ${{ env.BIN_DIR }}
-          mkdir ${{ env.RELEASE_DIR }}
-          cross build --release --all-features --target ${{ env.LINUX_TARGET }} -Z registry-auth
-          mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-          CARGO_HOME: ${{ github.workspace }}/.cargo
-
-      - name: Upload as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: linux
-          path: ./${{ env.RELEASE_DIR }}
-
-  compile-macos:
-    runs-on: macos-latest
-    needs: get-version
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Inject Version
-        run: |
-          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.full_version }}
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-09-13
-          target: ${{ env.MACOS_TARGET }}
-          override: true
-      
-      - name: Download cached dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-            shared-key: "macos-cross-builds"
-
-      - name: Build CLI MacOs Target
-        run: |
-          cargo install cross
-          cross build --release --all-features --target ${{ env.MACOS_TARGET }} -Z registry-auth
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-
-      - name: Install 7z cli
-        run: brew install p7zip
-
-      - name: Setup directories
-        run: |
-          mkdir ${{ env.BIN_DIR }}
-          mkdir ${{ env.RELEASE_DIR }}
-
-      - name: Compress binary
-        run: |
-          mv target/${{env.MACOS_TARGET}}/release/ev-cage ${{ env.BIN_DIR }}/ev-cage
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ${{ env.RELEASE_DIR }}/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
-
-      - name: Upload as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: macos
-          path: ./${{ env.RELEASE_DIR }}
-
-  compile-windows:
-    runs-on: windows-latest
-    needs: get-version
-    env:
-      VCPKGRS_DYNAMIC: 1
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install Rust
-        run: rustup update --no-self-update stable && rustup default stable
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-2023-09-13
-          target: ${{ env.WINDOWS_TARGET }}
-          override: true
-
-      - name: Inject Version
-        run: |
-          sh ./scripts/insert-cli-version.sh ${{ needs.get-version.outputs.full_version }}
-
-      - name: Download cached dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-            shared-key: "windows-cross-builds"
-
-      - name: Fetch dependencies
-        run: cargo fetch -Z registry-auth
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-
-      - name: Build CLI for Windows
-        run: |
-          cargo install cross
-          cross build --release --all-features --target ${{ env.WINDOWS_TARGET }} -Z registry-auth
-        env:
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
-          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
-
-      - name: Setup directories
-        shell: bash
-        run: |
-          mkdir ${{ env.BIN_DIR }}
-          mkdir ${{ env.RELEASE_DIR }}
-
-      - name: Compress
-        shell: bash
-        run: |
-          mv target/${{ env.WINDOWS_TARGET }}/release/ev-cage.exe ${{ env.BIN_DIR }}/ev-cage.exe
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
-
-      - name: Upload as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: windows
-          path: ./${{ env.RELEASE_DIR }}
-
-  release-cli-version:
-    needs: [ get-version, compile-ubuntu, compile-macos, compile-windows ]
+  release-cli-version: 
+    needs: [ build-and-deploy ]
     runs-on: ubuntu-latest
     steps:
 
@@ -243,6 +104,7 @@ jobs:
 
       - name: Upload Windows Release
         uses: actions/upload-release-asset@v1
+        
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -250,55 +112,3 @@ jobs:
           asset_path: ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
           asset_content_type: application/gzip
           asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
-
-  upload-artifacts-to-s3:
-    needs: [ get-version , compile-ubuntu, compile-macos, compile-windows ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Download MacOS Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: macos
-
-      - name: Download Linux Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: linux
-
-      - name: Download Windows Artifacts
-        uses: actions/download-artifact@v1
-        with:
-          name: windows
-
-      - name: Upload Windows CLI to S3
-        run: |
-          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.major_version }}/${{ needs.get-version.outputs.full_version }}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
-
-      - name: Upload MacOS CLI to S3
-        run: |
-          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.major_version }}/${{ needs.get-version.outputs.full_version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
-
-      - name: Upload Ubuntu CLI to S3
-        run: |
-          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.major_version }}/${{ needs.get-version.outputs.full_version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
-
-      - uses: actions/checkout@v2
-      - name: Update install script in S3
-        run: |
-          sh ./scripts/generate-installer.sh ${{ needs.get-version.outputs.full_version }} ${{ needs.get-version.outputs.major_version }}
-          sh ./scripts/update-versions.sh ${{ needs.get-version.outputs.full_version }}
-          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/${{ needs.get-version.outputs.major_version }}/${{needs.get-version.outputs.full_version}}/install
-          aws s3 cp scripts/install s3://cage-build-assets-${{ env.STAGE }}/cli/install
-          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/${{needs.get-version.outputs.major_version}}/version
-          aws s3 cp scripts/version s3://cage-build-assets-${{ env.STAGE }}/cli/version
-          aws s3 cp scripts/versions s3://cage-build-assets-${{ env.STAGE }}/cli/versions
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/install"
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/version"
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/cli/versions"

--- a/scripts/generate-installer.sh
+++ b/scripts/generate-installer.sh
@@ -2,8 +2,10 @@
 
 pattern="s/{{version}}/$1/"
 major_pattern="s/{{major}}/$2/"
+domain_pattern="s/{{domain}}/$3/"
 
-sed -e "$pattern" ./scripts/install.template > ./scripts/install
-sed -e "$major_pattern" ./scripts/install > ./scripts/install
+sed -e "$pattern" ./scripts/install.template > ./scripts/install-temp
+sed -e "$domain_pattern" ./scripts/install-temp > ./scripts/install-temp-domain
+sed -e "$major_pattern" ./scripts/install-temp-domain > ./scripts/install
 
 sed -e "$pattern" ./scripts/version.template > ./scripts/version

--- a/scripts/install.template
+++ b/scripts/install.template
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -eu
 
-EV_DOWNLOAD_Darwin_universal="https://cage-build-assets.evervault.com/cli/{{major}}/{{version}}/x86_64-apple-darwin/ev-cage.tar.gz"
-EV_DOWNLOAD_Windows_x86_64="https://cage-build-assets.evervault.com/cli/{{major}}/{{version}}/x86_64-pc-windows-msvc/ev-cage.tar.gz"
-EV_DOWNLOAD_Linux_x86_64="https://cage-build-assets.evervault.com/cli/{{major}}/{{version}}/x86_64-unknown-linux-musl/ev-cage.tar.gz"
+EV_DOWNLOAD_Darwin_universal="https://cage-build-assets.{{domain}}/cli/{{major}}/{{version}}/x86_64-apple-darwin/ev-cage.tar.gz"
+EV_DOWNLOAD_Windows_x86_64="https://cage-build-assets.{{domain}}/cli/{{major}}/{{version}}/x86_64-pc-windows-msvc/ev-cage.tar.gz"
+EV_DOWNLOAD_Linux_x86_64="https://cage-build-assets.{{domain}}/cli/{{major}}/{{version}}/x86_64-unknown-linux-musl/ev-cage.tar.gz"
 
 VERSION="{{version}}"
 PLATFORM=`uname -s`


### PR DESCRIPTION
# Why
We need to publish staging versions of the cli for prerelease testing

# How
Publish to cage-build-assets-staging
