### PR TITLE
Rename Cages -> Enclaves

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -71,8 +71,8 @@ jobs:
           mkdir ${{ env.BIN_DIR }}
           mkdir ${{ env.RELEASE_DIR }}
           cross build --release --all-features --target ${{ env.LINUX_TARGET }} -Z registry-auth
-          mv ./target/${{ env.LINUX_TARGET }}/release/ev-cage ./${{ env.BIN_DIR }}/ev-cage
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz
+          mv ./target/${{ env.LINUX_TARGET }}/release/ev-enclave ./${{ env.BIN_DIR }}/ev-enclave
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-enclave-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.evervault-rust-lib-index }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.evervault-rust-lib-token }}
@@ -122,8 +122,8 @@ jobs:
 
       - name: Compress binary
         run: |
-          mv target/${{env.MACOS_TARGET}}/release/ev-cage ${{ env.BIN_DIR }}/ev-cage
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ${{ env.RELEASE_DIR }}/ev-cage-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz
+          mv target/${{env.MACOS_TARGET}}/release/ev-enclave ${{ env.BIN_DIR }}/ev-enclave
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ${{ env.RELEASE_DIR }}/ev-enclave-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz
 
       - name: Upload as artifact
         uses: actions/upload-artifact@v2
@@ -179,8 +179,8 @@ jobs:
       - name: Compress
         shell: bash
         run: |
-          mv target/${{ env.WINDOWS_TARGET }}/release/ev-cage.exe ${{ env.BIN_DIR }}/ev-cage.exe
-          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-cage-${{ env.WINDOWS_TARGET }}-${{ inputs.full-version }}.tar.gz
+          mv target/${{ env.WINDOWS_TARGET }}/release/ev-enclave.exe ${{ env.BIN_DIR }}/ev-enclave.exe
+          7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-enclave-${{ env.WINDOWS_TARGET }}-${{ inputs.full-version }}.tar.gz
 
       - name: Upload as artifact
         uses: actions/upload-artifact@v2
@@ -217,26 +217,26 @@ jobs:
 
       - name: Upload Windows CLI to S3
         run: |
-          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version}}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./windows/ev-enclave-${{ env.WINDOWS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://enclave-build-assets-${{ inputs.stage }}/cli/${{ inputs.full-version }}/${{ inputs.full-version}}/${{ env.WINDOWS_TARGET }}/ev-enclave.tar.gz
 
       - name: Upload MacOS CLI to S3
         run: |
-          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./macos/ev-enclave-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://enclave-build-assets-${{ inputs.stage }}/cli/${{ inputs.full-version }}/${{ inputs.full-version }}/${{ env.MACOS_TARGET }}/ev-enclave.tar.gz
 
       - name: Upload Ubuntu CLI to S3
         run: |
-          aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./linux/ev-enclave-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz s3://enclave-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/${{ env.LINUX_TARGET }}/ev-enclave.tar.gz
 
       - uses: actions/checkout@v3
       - name: Update install script in S3
         run: |
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }}
           sh ./scripts/update-versions.sh ${{ inputs.full-version }}
-          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install
-          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/install
-          aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/version
-          aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/version
-          aws s3 cp scripts/versions s3://cage-build-assets-${{ inputs.stage }}/cli/versions
+          aws s3 cp scripts/install s3://enclave-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install
+          aws s3 cp scripts/install s3://enclave-build-assets-${{ inputs.stage }}/cli/install
+          aws s3 cp scripts/version s3://enclave-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/version
+          aws s3 cp scripts/version s3://enclave-build-assets-${{ inputs.stage }}/cli/version
+          aws s3 cp scripts/versions s3://enclave-build-assets-${{ inputs.stage }}/cli/versions
           aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/cli/install" "/cli/version" "/cli/versions"
 
 

--- a/.github/workflows/lint-and-test-cli.yml
+++ b/.github/workflows/lint-and-test-cli.yml
@@ -21,12 +21,12 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Compile project
-        run: cargo build --all-features -p ev-cage -Z registry-auth
+        run: cargo build --all-features -p ev-enclave -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
       - name: Test project
-        run: cargo test -p ev-cage
+        run: cargo test -p ev-enclave
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
       - name: Format project

--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -17,12 +17,12 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Compile project
-        run: cargo build --all-features -p ev-cage -Z registry-auth
+        run: cargo build --all-features -p ev-enclave -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
       - name: Test project
-        run: cargo test -p ev-cage
+        run: cargo test -p ev-enclave
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
       - name: Format project

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -1,4 +1,4 @@
-name: Release Cage CLI version
+name: Release Enclave CLI version
 
 on:
   push:
@@ -88,9 +88,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
+          asset_path: ./linux/ev-enclave-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
           asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
+          asset_name: ev-enclave-${{ env.LINUX_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
 
       - name: Upload MacOS Release
         uses: actions/upload-release-asset@v1
@@ -98,9 +98,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
+          asset_path: ./macos/ev-enclave-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
           asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
+          asset_name: ev-enclave-${{ env.MACOS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
 
       - name: Upload Windows Release
         uses: actions/upload-release-asset@v1
@@ -109,6 +109,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
+          asset_path: ./windows/ev-enclave-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
           asset_content_type: application/gzip
-          asset_name: ev-cage-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz
+          asset_name: ev-enclave-${{ env.WINDOWS_TARGET }}-${{ needs.get-version.outputs.full_version }}.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,8 +935,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "ev-cage"
-version = "0.0.0-dev"
+name = "ev-enclave"
+version = "1.0.0-dev"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "ev-cage"
-version = "0.0.0-dev"
+name = "ev-enclave"
+version = "1.0.0-dev"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,109 +1,12 @@
 <a href="https://evervault.com/cages"><img src="https://evervault.com/images/logo-color.svg" height="45" /></a>
 
-# Cages CLI
+# Enclave CLI
 
-Command Line Tool to build, deploy and manage Evervault [Cages](https://github.com/evervault/cages/)
+Command Line Tool to build, deploy and manage Evervault [Enclaves](https://github.com/evervault/cages/)
 
 ## Notice on Open Source Status of this project
-The Evervault Cages product is open source with the aim of providing transparency to users — this is vital given that our process runs in the enclave, and is accounted for in the attestation.
+The Evervault Enclaves product is open source with the aim of providing transparency to users — this is vital given that our process runs in the enclave, and is accounted for in the attestation.
 
-The current state of this project does not allow for self-hosting. We plan on addressing this by abstracting away the Evervault-specific elements of the Cages product.
+The current state of this project does not allow for self-hosting. We plan on addressing this by abstracting away the Evervault-specific elements of the Enclaves product.
 
-## Subcommands
-
-### init
-
-Initialize a Cage.toml in the current directory. Must provide a cage name.
-
-`ev-cage init --name my-cage`
-
-### build
-
-Build a Cage from a Dockerfile. Defaults to use local `cage.toml` file for configuration. See more options with `-h`.
-
-`ev-cage build`
-
-### deploy
-
-Deploy a Cage from a toml file. Builds a cage from a Dockerfile and then deploys the cage. You can provide a path to an EIF which was already build. See more options with `-h`.
-
-`ev-cage deploy`
-
-### delete
-
-Delete a Cage from a toml file.
-
-`ev-cage delete`
-
-### attest
-
-Validate the attestation doc provided by a Cage. Defaults to compare against the local `cage.toml` file.
-
-### env
-
-Manage Cage environment. Any changes to environment variables require a deployment to take effect.
-
-#### add
-
-Add a Cage environment variable. Add `--secret` to encrypt the value.
-
-`ev-cage env add --key ENV_VAR_1 --value ENV_VAR`
-
-#### get
-
-Get Cage environment variables.
-
-`ev-cage env get`
-
-#### delete
-
-Delete a Cage environment variable. 
-
-`ev-cage env delete --key ENV_VAR_1`
-
-### describe
-
-Get the PCRs of a built EIF. Defaults to `./enclave.eif`
-
-`ev-cage describe `
-
-### list
-
-List your Cages and Deployments.
-
-#### cages
-
-List Cages
-
-`ev-cage list cages`
-
-#### deployments
-
-List Deployments of a specific cage. Defaults to the local `./cage.toml` file
-
-`ev-cage list deployments`
-
-### cert
-
-Create a new Cage signing certificate
-
-`ev-cage cert new`
-
-### logs
-
-Pull the logs for a Cage into. Defaults to the local `./cage.toml` file.
-
-`ev-cage logs`
-
-### encrypt
-
-Encrypt a string with the CLI.
-
-`ev-cage encrypt super-secret-value`
-
-### update
-
-Check for new versions of the CLI and install them.
-
-`ev-cage update`
-
+Learn more in the [docs](https://docs.evervault.com/primitives/cages#cages-cli-reference)

--- a/scripts/insert-cli-version.sh
+++ b/scripts/insert-cli-version.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-pattern="s/0.0.0-dev/$1/"
+pattern="s/1.0.0-dev/$1/"
 sed -i -e "$pattern" ./Cargo.toml

--- a/scripts/install.template
+++ b/scripts/install.template
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -eu
 
-EV_DOWNLOAD_Darwin_universal="https://cage-build-assets.{{domain}}/cli/{{major}}/{{version}}/x86_64-apple-darwin/ev-cage.tar.gz"
-EV_DOWNLOAD_Windows_x86_64="https://cage-build-assets.{{domain}}/cli/{{major}}/{{version}}/x86_64-pc-windows-msvc/ev-cage.tar.gz"
-EV_DOWNLOAD_Linux_x86_64="https://cage-build-assets.{{domain}}/cli/{{major}}/{{version}}/x86_64-unknown-linux-musl/ev-cage.tar.gz"
+EV_DOWNLOAD_Darwin_universal="https://enclave-build-assets.{{domain}}/cli/{{major}}/{{version}}/x86_64-apple-darwin/ev-enclave.tar.gz"
+EV_DOWNLOAD_Windows_x86_64="https://enclave-build-assets.{{domain}}/cli/{{major}}/{{version}}/x86_64-pc-windows-msvc/ev-enclave.tar.gz"
+EV_DOWNLOAD_Linux_x86_64="https://enclave-build-assets.{{domain}}/cli/{{major}}/{{version}}/x86_64-unknown-linux-musl/ev-enclave.tar.gz"
 
 VERSION="{{version}}"
 PLATFORM=`uname -s`
@@ -38,9 +38,9 @@ if [ ! -d "$INSTALL_DIR" ]; then
 fi
 if [ -z ${INSTALL_PATH+x} ]; then
   if [ "$PLATFORM" = "Windows" ]; then
-    INSTALL_PATH="${INSTALL_DIR}/ev-cage.exe"
+    INSTALL_PATH="${INSTALL_DIR}/ev-enclave.exe"
   else
-    INSTALL_PATH="${INSTALL_DIR}/ev-cage"
+    INSTALL_PATH="${INSTALL_DIR}/ev-enclave"
   fi
 fi
 DOWNLOAD_URL_LOOKUP="EV_DOWNLOAD_${PLATFORM}_${ARCH}"
@@ -52,7 +52,7 @@ ensure_supported_platform() {
 }
 ensure_supported_platform
 
-echo "This script will automatically install the Evervault Cage CLI@${VERSION} for you."
+echo "This script will automatically install the Evervault Enclave CLI@${VERSION} for you."
 echo "Installation path: ${INSTALL_PATH}"
 if [ "x$(id -u)" = "x0" ]; then
   echo "Warning: this script is currently running as root. This is dangerous. "
@@ -60,8 +60,8 @@ if [ "x$(id -u)" = "x0" ]; then
 fi
 
 if [ -f "$INSTALL_PATH" ]; then
-  if [ -z ${CAGE_CLI_FORCE_INSTALL+x} ]; then
-    echo "Looks like you already have the Evervault Cage CLI installed. You can update by running ev-cage update"
+  if [ -z ${CLI_FORCE_INSTALL+x} ]; then
+    echo "Looks like you already have the Evervault Enclave CLI installed. You can update by running ev-enclave update"
     exit 0
   else
     echo "Proceeding with update..."
@@ -79,7 +79,7 @@ fi
 eval DOWNLOAD_URL=\$$DOWNLOAD_URL_LOOKUP
 
 if [ "$PERFORM_INSTALL" = true ]; then
-  TEMP_FILE=`mktemp "${TMPDIR:-/tmp}/ev-cage.XXXXXXXX"`
+  TEMP_FILE=`mktemp "${TMPDIR:-/tmp}/ev-enclave.XXXXXXXX"`
 fi
 
 cleanup() {
@@ -112,12 +112,12 @@ if [ "$PERFORM_INSTALL" = true ]; then
 fi
 
 extract_via_7zip() {
-   TARGET_DIR=`mktemp -d "${TMPDIR:-/tmp}/ev-cage.XXXXXX"`
+   TARGET_DIR=`mktemp -d "${TMPDIR:-/tmp}/ev-enclave.XXXXXX"`
    7z x "$TEMP_FILE" -so | 7z x -aoa -si -ttar -o"$TARGET_DIR"
 }
 
 extract_via_tar() {
-  TARGET_DIR=`mktemp -d "${TMPDIR:-/tmp}/ev-cage.XXXXXX"`
+  TARGET_DIR=`mktemp -d "${TMPDIR:-/tmp}/ev-enclave.XXXXXX"`
   tar xzf "$TEMP_FILE" -C "$TARGET_DIR"
 }
 
@@ -131,11 +131,11 @@ fi
 
 get_file_location() {
   if [ "$PLATFORM" = "Darwin" ]; then
-    EV_BINARY="${TARGET_DIR}/bin/ev-cage"
+    EV_BINARY="${TARGET_DIR}/bin/ev-enclave"
   elif [ "$PLATFORM" = "Windows" ]; then
-    EV_BINARY="${TARGET_DIR}/bin/ev-cage.exe"
+    EV_BINARY="${TARGET_DIR}/bin/ev-enclave.exe"
   else
-    EV_BINARY="${TARGET_DIR}/bin/ev-cage"
+    EV_BINARY="${TARGET_DIR}/bin/ev-enclave"
   fi
   chmod 0755 "$EV_BINARY"
 }

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -25,7 +25,7 @@ major_version=$(echo "$release_version" | cut -d '.' -f 1)
 
 echo "Release major version: $major_version"
 
-version_json=$(curl -s "https://cage-build-assets.evervault.com/cli/versions")
+version_json=$(curl -s "https://enclave-build-assets.evervault.com/cli/versions")
 echo "Version response: $version_json"
 
 if [ $? -eq 0 ]; then

--- a/src/api/assets.rs
+++ b/src/api/assets.rs
@@ -40,7 +40,7 @@ impl ApiClient for AssetsClient {
 
     fn base_url(&self) -> String {
         let domain = std::env::var("EV_DOMAIN").unwrap_or_else(|_| String::from("evervault.com"));
-        format!("https://cage-build-assets.{}", domain)
+        format!("https://enclave-build-assets.{}", domain)
     }
 
     fn auth(&self) -> &super::AuthMode {

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -72,7 +72,7 @@ pub trait ApiClient {
     }
 
     fn user_agent(&self) -> String {
-        format!("evervault-cage-cli/{}", env!("CARGO_PKG_VERSION"))
+        format!("evervault-enclave-cli/{}", env!("CARGO_PKG_VERSION"))
     }
 
     fn accept(&self) -> String {
@@ -110,6 +110,7 @@ pub trait ApiClient {
         request_builder = request_builder
             .header(reqwest::header::USER_AGENT, self.user_agent())
             .header(reqwest::header::ACCEPT, self.accept());
+
         match &self.auth() {
             AuthMode::NoAuth => request_builder,
             AuthMode::ApiKey(api_key) => request_builder.header("api-key", api_key),
@@ -128,6 +129,7 @@ pub trait HandleResponse {
 #[async_trait]
 impl HandleResponse for ReqwestResult<Response> {
     async fn handle_json_response<T: DeserializeOwned>(self) -> ApiResult<T> {
+        println!("self: {:?}", self);
         match self {
             Ok(res) if res.status().is_success() => res
                 .json()
@@ -193,8 +195,8 @@ impl ApiErrorKind {
             Self::Conflict => "409: Conflict".to_owned(),
             Self::Internal => "500: Internal Server Error".to_owned(),
             Self::Unknown(e) => format!("An unexpected error occured: {:?}", e),
-            Self::ParsingError(_) => {
-                "An error occurred while parsing the server's response.to_owned()".to_owned()
+            Self::ParsingError(e) => {
+                format!("An error occurred while parsing the server's response: {e:?}")
             }
         }
     }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -129,7 +129,6 @@ pub trait HandleResponse {
 #[async_trait]
 impl HandleResponse for ReqwestResult<Response> {
     async fn handle_json_response<T: DeserializeOwned>(self) -> ApiResult<T> {
-        println!("self: {:?}", self);
         match self {
             Ok(res) if res.status().is_success() => res
                 .json()

--- a/src/api/enclave.rs
+++ b/src/api/enclave.rs
@@ -452,7 +452,7 @@ impl CreateEnclaveRequest {
 #[serde(rename_all = "camelCase")]
 pub struct CreateEnclaveDeploymentIntentResponse {
     signed_url: String,
-    uuid: String,
+    enclave_uuid: String,
     deployment_uuid: String,
     version: u32,
 }
@@ -463,7 +463,7 @@ impl CreateEnclaveDeploymentIntentResponse {
     }
 
     pub fn enclave_uuid(&self) -> &str {
-        &self.uuid
+        &self.enclave_uuid
     }
 
     pub fn deployment_uuid(&self) -> &str {
@@ -754,14 +754,14 @@ impl GetEnclaveResponse {
 pub struct GetEnclaveDeploymentResponse {
     #[serde(flatten)]
     pub deployment: EnclaveDeployment,
-    pub tee_enclave_version: EnclaveVersion,
-    pub tee_enclave_signing_cert: EnclaveSigningCert,
-    pub tee_enclave_regional_deployments: Vec<EnclaveRegionalDeployment>,
+    pub enclave_version: EnclaveVersion,
+    pub enclave_signing_cert: EnclaveSigningCert,
+    pub enclave_regional_deployments: Vec<EnclaveRegionalDeployment>,
 }
 
 impl GetEnclaveDeploymentResponse {
     pub fn is_built(&self) -> bool {
-        matches!(self.tee_enclave_version.build_status, BuildStatus::Ready)
+        matches!(self.enclave_version.build_status, BuildStatus::Ready)
     }
 
     pub fn is_finished(&self) -> bool {
@@ -770,25 +770,25 @@ impl GetEnclaveDeploymentResponse {
 
     //TODO: Handle multi region deployment failures
     pub fn is_failed(&self) -> bool {
-        let build_failed = matches!(self.tee_enclave_version.build_status, BuildStatus::Failed);
+        let build_failed = matches!(self.enclave_version.build_status, BuildStatus::Failed);
         build_failed
             || self
-                .tee_enclave_regional_deployments
+                .enclave_regional_deployments
                 .first()
                 .map(|depl| depl.is_failed())
                 .unwrap_or_default()
     }
 
     pub fn get_failure_reason(&self) -> Option<String> {
-        self.tee_enclave_version.failure_reason.clone().or_else(|| {
-            self.tee_enclave_regional_deployments
+        self.enclave_version.failure_reason.clone().or_else(|| {
+            self.enclave_regional_deployments
                 .first()
                 .map(|depl| depl.get_failure_reason())
         })
     }
 
     pub fn get_detailed_status(&self) -> Option<String> {
-        self.tee_enclave_regional_deployments
+        self.enclave_regional_deployments
             .first()
             .map(|depl| depl.get_detailed_status())
     }
@@ -939,9 +939,9 @@ mod test {
         let cert = get_testing_cert();
         let deployment_with_empty_regional = GetEnclaveDeploymentResponse {
             deployment,
-            tee_enclave_version: version,
-            tee_enclave_signing_cert: cert,
-            tee_enclave_regional_deployments: vec![],
+            enclave_version: version,
+            enclave_signing_cert: cert,
+            enclave_regional_deployments: vec![],
         };
 
         assert!(deployment_with_empty_regional
@@ -963,9 +963,9 @@ mod test {
         let detailed_failure_reason = "Insufficient capacity".to_string();
         let deployment_with_regional = GetEnclaveDeploymentResponse {
             deployment,
-            tee_enclave_version: version,
-            tee_enclave_signing_cert: cert,
-            tee_enclave_regional_deployments: vec![EnclaveRegionalDeployment {
+            enclave_version: version,
+            enclave_signing_cert: cert,
+            enclave_regional_deployments: vec![EnclaveRegionalDeployment {
                 uuid: "abc".to_string(),
                 deployment_uuid: "def".to_string(),
                 deployment_order: 1,

--- a/src/api/enclave.rs
+++ b/src/api/enclave.rs
@@ -1,4 +1,4 @@
-use crate::config::ValidatedCageBuildConfig;
+use crate::config::ValidatedEnclaveBuildConfig;
 
 use super::client::{ApiClient, ApiClientError, ApiResult, GenericApiClient, HandleResponse};
 use super::AuthMode;
@@ -9,11 +9,11 @@ use serde::{Deserialize, Serialize};
 use mockall::automock;
 
 #[derive(Clone)]
-pub struct CagesClient {
+pub struct EnclaveClient {
     inner: GenericApiClient,
 }
 
-impl ApiClient for CagesClient {
+impl ApiClient for EnclaveClient {
     fn auth(&self) -> &AuthMode {
         self.inner.auth()
     }
@@ -28,62 +28,65 @@ impl ApiClient for CagesClient {
 
     fn base_url(&self) -> String {
         let api_base = self.inner.base_url();
-        format!("{}/v2/cages", api_base)
+        format!("{}/enclaves", api_base)
     }
 }
 
 #[async_trait::async_trait]
 #[cfg_attr(test, automock)]
-pub trait CageApi {
-    async fn create_cage(&self, cage_create_payload: CreateCageRequest) -> ApiResult<Cage>;
-    async fn create_cage_deployment_intent(
+pub trait EnclaveApi {
+    async fn create_enclave(
         &self,
-        cage_uuid: &str,
-        payload: CreateCageDeploymentIntentRequest,
-    ) -> ApiResult<CreateCageDeploymentIntentResponse>;
-    async fn create_cage_signing_cert_ref(
+        enclave_create_payload: CreateEnclaveRequest,
+    ) -> ApiResult<Enclave>;
+    async fn create_enclave_deployment_intent(
         &self,
-        payload: CreateCageSigningCertRefRequest,
-    ) -> ApiResult<CreateCageSigningCertRefResponse>;
-    async fn get_cages(&self) -> ApiResult<GetCagesResponse>;
-    async fn get_cage(&self, cage_uuid: &str) -> ApiResult<GetCageResponse>;
+        enclave_uuid: &str,
+        payload: CreateEnclaveDeploymentIntentRequest,
+    ) -> ApiResult<CreateEnclaveDeploymentIntentResponse>;
+    async fn create_enclave_signing_cert_ref(
+        &self,
+        payload: CreateEnclaveSigningCertRefRequest,
+    ) -> ApiResult<CreateEnclaveSigningCertRefResponse>;
+    async fn get_enclaves(&self) -> ApiResult<GetEnclavesResponse>;
+    async fn get_enclave(&self, enclave_uuid: &str) -> ApiResult<GetEnclaveResponse>;
     async fn get_app_keys(&self, team_uuid: &str, app_uuid: &str) -> ApiResult<GetKeysResponse>;
-    async fn add_env_var(&self, cage_uuid: String, payload: AddSecretRequest) -> ApiResult<()>;
-    async fn delete_env_var(&self, cage_uuid: String, name: String) -> ApiResult<()>;
-    async fn get_cage_env(&self, cage_uuid: String) -> ApiResult<CageEnv>;
-    async fn get_cage_deployment_by_uuid(
+    async fn add_env_var(&self, enclave_uuid: String, payload: AddSecretRequest) -> ApiResult<()>;
+    async fn delete_env_var(&self, enclave_uuid: String, name: String) -> ApiResult<()>;
+    async fn get_enclave_env(&self, enclave_uuid: String) -> ApiResult<EnclaveEnv>;
+    async fn get_enclave_deployment_by_uuid(
         &self,
-        cage_uuid: &str,
+        enclave_uuid: &str,
         deployment_uuid: &str,
-    ) -> ApiResult<GetCageDeploymentResponse>;
+    ) -> ApiResult<GetEnclaveDeploymentResponse>;
     async fn get_signing_certs(&self) -> ApiResult<GetSigningCertsResponse>;
-    async fn update_cage_locked_signing_certs(
+    async fn update_enclave_locked_signing_certs(
         &self,
-        cage_uuid: &str,
-        payload: UpdateLockedCageSigningCertRequest,
-    ) -> ApiResult<Vec<CageToSigningCert>>;
-    async fn get_cage_locked_signing_certs(
+        enclave_uuid: &str,
+        payload: UpdateLockedEnclaveSigningCertRequest,
+    ) -> ApiResult<Vec<EnclaveToSigningCert>>;
+    async fn get_enclave_locked_signing_certs(
         &self,
-        cage_uuid: &str,
-    ) -> ApiResult<Vec<CageSigningCert>>;
-    async fn get_cage_cert_by_uuid(&self, cert_uuid: &str) -> ApiResult<CageSigningCert>;
-    async fn get_cage_logs(
+        enclave_uuid: &str,
+    ) -> ApiResult<Vec<EnclaveSigningCert>>;
+    async fn get_enclave_cert_by_uuid(&self, cert_uuid: &str) -> ApiResult<EnclaveSigningCert>;
+    async fn get_enclave_logs(
         &self,
-        cage_uuid: &str,
+        enclave_uuid: &str,
         start_time: u128,
         end_time: u128,
-    ) -> ApiResult<CageLogs>;
-    async fn delete_cage(&self, cage_uuid: &str) -> ApiResult<DeleteCageResponse>;
-    async fn restart_cage(&self, cage_uuid: &str) -> ApiResult<CageDeployment>;
-    async fn get_scaling_config(&self, cage_uuid: &str) -> ApiResult<CageScalingConfig>;
+    ) -> ApiResult<EnclaveLogs>;
+    async fn delete_enclave(&self, enclave_uuid: &str) -> ApiResult<DeleteEnclaveResponse>;
+    async fn restart_enclave(&self, enclave_uuid: &str) -> ApiResult<EnclaveDeployment>;
+    async fn get_scaling_config(&self, enclave_uuid: &str) -> ApiResult<EnclaveScalingConfig>;
     async fn update_scaling_config(
         &self,
-        cage_uuid: &str,
-        update_scaling_config_request: UpdateCageScalingConfigRequest,
-    ) -> ApiResult<CageScalingConfig>;
+        enclave_uuid: &str,
+        update_scaling_config_request: UpdateEnclaveScalingConfigRequest,
+    ) -> ApiResult<EnclaveScalingConfig>;
 }
 
-impl CagesClient {
+impl EnclaveClient {
     pub fn new(auth_mode: AuthMode) -> Self {
         Self {
             inner: GenericApiClient::from(auth_mode),
@@ -92,23 +95,26 @@ impl CagesClient {
 }
 
 #[async_trait::async_trait]
-impl CageApi for CagesClient {
-    async fn create_cage(&self, cage_create_payload: CreateCageRequest) -> ApiResult<Cage> {
-        let create_cage_url = format!("{}/", self.base_url());
-        self.post(&create_cage_url)
-            .json(&cage_create_payload)
+impl EnclaveApi for EnclaveClient {
+    async fn create_enclave(
+        &self,
+        enclave_create_payload: CreateEnclaveRequest,
+    ) -> ApiResult<Enclave> {
+        let create_enclave_url = format!("{}/", self.base_url());
+        self.post(&create_enclave_url)
+            .json(&enclave_create_payload)
             .send()
             .await
             .handle_json_response()
             .await
     }
 
-    async fn create_cage_deployment_intent(
+    async fn create_enclave_deployment_intent(
         &self,
-        cage_uuid: &str,
-        payload: CreateCageDeploymentIntentRequest,
-    ) -> ApiResult<CreateCageDeploymentIntentResponse> {
-        let deployment_intent_url = format!("{}/{}/credentials", self.base_url(), cage_uuid);
+        enclave_uuid: &str,
+        payload: CreateEnclaveDeploymentIntentRequest,
+    ) -> ApiResult<CreateEnclaveDeploymentIntentResponse> {
+        let deployment_intent_url = format!("{}/{}/credentials", self.base_url(), enclave_uuid);
         self.post(&deployment_intent_url)
             .json(&payload)
             .send()
@@ -117,10 +123,10 @@ impl CageApi for CagesClient {
             .await
     }
 
-    async fn create_cage_signing_cert_ref(
+    async fn create_enclave_signing_cert_ref(
         &self,
-        payload: CreateCageSigningCertRefRequest,
-    ) -> ApiResult<CreateCageSigningCertRefResponse> {
+        payload: CreateEnclaveSigningCertRefRequest,
+    ) -> ApiResult<CreateEnclaveSigningCertRefResponse> {
         let signing_cert_url = format!("{}/signing/certs", self.base_url());
         self.post(&signing_cert_url)
             .json(&payload)
@@ -130,18 +136,18 @@ impl CageApi for CagesClient {
             .await
     }
 
-    async fn get_cages(&self) -> ApiResult<GetCagesResponse> {
-        let get_cages_url = format!("{}/", self.base_url());
-        self.get(&get_cages_url)
+    async fn get_enclaves(&self) -> ApiResult<GetEnclavesResponse> {
+        let get_enclaves_url = format!("{}/", self.base_url());
+        self.get(&get_enclaves_url)
             .send()
             .await
             .handle_json_response()
             .await
     }
 
-    async fn get_cage(&self, cage_uuid: &str) -> ApiResult<GetCageResponse> {
-        let get_cage_url = format!("{}/{}", self.base_url(), cage_uuid);
-        self.get(&get_cage_url)
+    async fn get_enclave(&self, enclave_uuid: &str) -> ApiResult<GetEnclaveResponse> {
+        let get_enclave_url = format!("{}/{}", self.base_url(), enclave_uuid);
+        self.get(&get_enclave_url)
             .send()
             .await
             .handle_json_response()
@@ -149,16 +155,16 @@ impl CageApi for CagesClient {
     }
 
     async fn get_app_keys(&self, team_uuid: &str, app_uuid: &str) -> ApiResult<GetKeysResponse> {
-        let get_cage_url = format!("{}/{}/apps/{}", self.keys_url(), team_uuid, app_uuid);
-        self.get(&get_cage_url)
+        let get_enclave_url = format!("{}/{}/apps/{}", self.keys_url(), team_uuid, app_uuid);
+        self.get(&get_enclave_url)
             .send()
             .await
             .handle_json_response()
             .await
     }
 
-    async fn add_env_var(&self, cage_uuid: String, payload: AddSecretRequest) -> ApiResult<()> {
-        let add_env_url = format!("{}/{}/secrets", self.base_url(), cage_uuid);
+    async fn add_env_var(&self, enclave_uuid: String, payload: AddSecretRequest) -> ApiResult<()> {
+        let add_env_url = format!("{}/{}/secrets", self.base_url(), enclave_uuid);
         self.put(&add_env_url)
             .json(&payload)
             .send()
@@ -166,16 +172,16 @@ impl CageApi for CagesClient {
             .handle_no_op_response()
     }
 
-    async fn delete_env_var(&self, cage_uuid: String, name: String) -> ApiResult<()> {
-        let delete_env_url = format!("{}/{}/secrets/{}", self.base_url(), cage_uuid, name);
+    async fn delete_env_var(&self, enclave_uuid: String, name: String) -> ApiResult<()> {
+        let delete_env_url = format!("{}/{}/secrets/{}", self.base_url(), enclave_uuid, name);
         self.delete(&delete_env_url)
             .send()
             .await
             .handle_no_op_response()
     }
 
-    async fn get_cage_env(&self, cage_uuid: String) -> ApiResult<CageEnv> {
-        let get_env_url = format!("{}/{}/secrets", self.base_url(), cage_uuid);
+    async fn get_enclave_env(&self, enclave_uuid: String) -> ApiResult<EnclaveEnv> {
+        let get_env_url = format!("{}/{}/secrets", self.base_url(), enclave_uuid);
         self.get(&get_env_url)
             .send()
             .await
@@ -183,18 +189,18 @@ impl CageApi for CagesClient {
             .await
     }
 
-    async fn get_cage_deployment_by_uuid(
+    async fn get_enclave_deployment_by_uuid(
         &self,
-        cage_uuid: &str,
+        enclave_uuid: &str,
         deployment_uuid: &str,
-    ) -> ApiResult<GetCageDeploymentResponse> {
-        let get_cage_url = format!(
+    ) -> ApiResult<GetEnclaveDeploymentResponse> {
+        let get_enclave_url = format!(
             "{}/{}/deployments/{}",
             self.base_url(),
-            cage_uuid,
+            enclave_uuid,
             deployment_uuid
         );
-        self.get(&get_cage_url)
+        self.get(&get_enclave_url)
             .send()
             .await
             .handle_json_response()
@@ -210,13 +216,14 @@ impl CageApi for CagesClient {
             .await
     }
 
-    async fn update_cage_locked_signing_certs(
+    async fn update_enclave_locked_signing_certs(
         &self,
-        cage_uuid: &str,
-        payload: UpdateLockedCageSigningCertRequest,
-    ) -> ApiResult<Vec<CageToSigningCert>> {
-        let get_cage_lock_certs_url = format!("{}/{}/signing/certs", self.base_url(), cage_uuid);
-        self.put(&get_cage_lock_certs_url)
+        enclave_uuid: &str,
+        payload: UpdateLockedEnclaveSigningCertRequest,
+    ) -> ApiResult<Vec<EnclaveToSigningCert>> {
+        let get_enclave_lock_certs_url =
+            format!("{}/{}/signing/certs", self.base_url(), enclave_uuid);
+        self.put(&get_enclave_lock_certs_url)
             .json(&payload)
             .send()
             .await
@@ -224,19 +231,20 @@ impl CageApi for CagesClient {
             .await
     }
 
-    async fn get_cage_locked_signing_certs(
+    async fn get_enclave_locked_signing_certs(
         &self,
-        cage_uuid: &str,
-    ) -> ApiResult<Vec<CageSigningCert>> {
-        let get_cage_lock_certs_url = format!("{}/{}/signing/certs", self.base_url(), cage_uuid);
-        self.get(&get_cage_lock_certs_url)
+        enclave_uuid: &str,
+    ) -> ApiResult<Vec<EnclaveSigningCert>> {
+        let get_enclave_lock_certs_url =
+            format!("{}/{}/signing/certs", self.base_url(), enclave_uuid);
+        self.get(&get_enclave_lock_certs_url)
             .send()
             .await
             .handle_json_response()
             .await
     }
 
-    async fn get_cage_cert_by_uuid(&self, cert_uuid: &str) -> ApiResult<CageSigningCert> {
+    async fn get_enclave_cert_by_uuid(&self, cert_uuid: &str) -> ApiResult<EnclaveSigningCert> {
         let get_cert_url = format!("{}/signing/certs/{}", self.base_url(), cert_uuid);
         self.get(&get_cert_url)
             .send()
@@ -245,16 +253,16 @@ impl CageApi for CagesClient {
             .await
     }
 
-    async fn get_cage_logs(
+    async fn get_enclave_logs(
         &self,
-        cage_uuid: &str,
+        enclave_uuid: &str,
         start_time: u128,
         end_time: u128,
-    ) -> ApiResult<CageLogs> {
+    ) -> ApiResult<EnclaveLogs> {
         let get_logs_url = format!(
             "{}/{}/logs?startTime={start_time}&endTime={end_time}",
             self.base_url(),
-            cage_uuid
+            enclave_uuid
         );
 
         self.get(&get_logs_url)
@@ -264,27 +272,27 @@ impl CageApi for CagesClient {
             .await
     }
 
-    async fn delete_cage(&self, cage_uuid: &str) -> ApiResult<DeleteCageResponse> {
-        let delete_cage_url = format!("{}/{}", self.base_url(), cage_uuid);
-        self.delete(&delete_cage_url)
+    async fn delete_enclave(&self, enclave_uuid: &str) -> ApiResult<DeleteEnclaveResponse> {
+        let delete_enclave_url = format!("{}/{}", self.base_url(), enclave_uuid);
+        self.delete(&delete_enclave_url)
             .send()
             .await
             .handle_json_response()
             .await
     }
 
-    async fn restart_cage(&self, cage_uuid: &str) -> ApiResult<CageDeployment> {
-        let patch_cage_url = format!("{}/{}", self.base_url(), cage_uuid);
-        self.patch(&patch_cage_url)
+    async fn restart_enclave(&self, enclave_uuid: &str) -> ApiResult<EnclaveDeployment> {
+        let patch_enclave_url = format!("{}/{}", self.base_url(), enclave_uuid);
+        self.patch(&patch_enclave_url)
             .send()
             .await
             .handle_json_response()
             .await
     }
 
-    async fn get_scaling_config(&self, cage_uuid: &str) -> ApiResult<CageScalingConfig> {
-        let cage_scaling_url = format!("{}/{}/scale", self.base_url(), cage_uuid);
-        self.get(&cage_scaling_url)
+    async fn get_scaling_config(&self, enclave_uuid: &str) -> ApiResult<EnclaveScalingConfig> {
+        let enclave_scaling_url = format!("{}/{}/scale", self.base_url(), enclave_uuid);
+        self.get(&enclave_scaling_url)
             .send()
             .await
             .handle_json_response()
@@ -293,11 +301,11 @@ impl CageApi for CagesClient {
 
     async fn update_scaling_config(
         &self,
-        cage_uuid: &str,
-        update_scaling_config_request: UpdateCageScalingConfigRequest,
-    ) -> ApiResult<CageScalingConfig> {
-        let cage_scaling_url = format!("{}/{}/scale", self.base_url(), cage_uuid);
-        self.put(&cage_scaling_url)
+        enclave_uuid: &str,
+        update_scaling_config_request: UpdateEnclaveScalingConfigRequest,
+    ) -> ApiResult<EnclaveScalingConfig> {
+        let enclave_scaling_url = format!("{}/{}/scale", self.base_url(), enclave_uuid);
+        self.put(&enclave_scaling_url)
             .json(&update_scaling_config_request)
             .send()
             .await
@@ -317,7 +325,7 @@ pub struct VersionMetadata {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateCageDeploymentIntentRequest {
+pub struct CreateEnclaveDeploymentIntentRequest {
     #[serde(flatten)]
     pcrs: crate::enclave::PCRs,
     debug_mode: bool,
@@ -335,10 +343,10 @@ pub struct CreateCageDeploymentIntentRequest {
     desired_replicas: Option<u32>,
 }
 
-impl CreateCageDeploymentIntentRequest {
+impl CreateEnclaveDeploymentIntentRequest {
     pub fn new(
         pcrs: &crate::enclave::PCRs,
-        config: ValidatedCageBuildConfig,
+        config: ValidatedEnclaveBuildConfig,
         eif_size_bytes: u64,
         data_plane_version: String,
         installer_version: String,
@@ -369,14 +377,14 @@ impl CreateCageDeploymentIntentRequest {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateCageSigningCertRefRequest {
+pub struct CreateEnclaveSigningCertRefRequest {
     cert_hash: String,
     name: String,
     not_before: String,
     not_after: String,
 }
 
-impl CreateCageSigningCertRefRequest {
+impl CreateEnclaveSigningCertRefRequest {
     pub fn new(cert_hash: String, name: String, not_before: String, not_after: String) -> Self {
         Self {
             cert_hash,
@@ -389,11 +397,11 @@ impl CreateCageSigningCertRefRequest {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct UpdateLockedCageSigningCertRequest {
+pub struct UpdateLockedEnclaveSigningCertRequest {
     cert_uuids: Vec<String>,
 }
 
-impl UpdateLockedCageSigningCertRequest {
+impl UpdateLockedEnclaveSigningCertRequest {
     pub fn new(cert_uuids: Vec<String>) -> Self {
         Self { cert_uuids }
     }
@@ -401,7 +409,7 @@ impl UpdateLockedCageSigningCertRequest {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateCageRequest {
+pub struct CreateEnclaveRequest {
     name: String,
     is_time_bound: bool,
 }
@@ -415,13 +423,13 @@ pub struct AddSecretRequest {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CageSecrets {
+pub struct EnclaveSecrets {
     pub name: String,
     pub secret: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CageEnv {
+pub struct EnclaveEnv {
     pub secrets: Vec<Secret>,
 }
 
@@ -431,10 +439,10 @@ pub struct Secret {
     pub secret: String,
 }
 
-impl CreateCageRequest {
-    pub fn new(cage_name: String, is_time_bound: bool) -> Self {
+impl CreateEnclaveRequest {
+    pub fn new(enclave_name: String, is_time_bound: bool) -> Self {
         Self {
-            name: cage_name,
+            name: enclave_name,
             is_time_bound,
         }
     }
@@ -442,20 +450,20 @@ impl CreateCageRequest {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateCageDeploymentIntentResponse {
+pub struct CreateEnclaveDeploymentIntentResponse {
     signed_url: String,
-    cage_uuid: String,
+    uuid: String,
     deployment_uuid: String,
     version: u32,
 }
 
-impl CreateCageDeploymentIntentResponse {
+impl CreateEnclaveDeploymentIntentResponse {
     pub fn signed_url(&self) -> &str {
         &self.signed_url
     }
 
-    pub fn cage_uuid(&self) -> &str {
-        &self.cage_uuid
+    pub fn enclave_uuid(&self) -> &str {
+        &self.uuid
     }
 
     pub fn deployment_uuid(&self) -> &str {
@@ -469,7 +477,7 @@ impl CreateCageDeploymentIntentResponse {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateCageSigningCertRefResponse {
+pub struct CreateEnclaveSigningCertRefResponse {
     cert_hash: String,
     not_before: String,
     not_after: String,
@@ -477,7 +485,7 @@ pub struct CreateCageSigningCertRefResponse {
     uuid: String,
 }
 
-impl CreateCageSigningCertRefResponse {
+impl CreateEnclaveSigningCertRefResponse {
     pub fn cert_hash(&self) -> &str {
         &self.cert_hash
     }
@@ -501,14 +509,14 @@ impl CreateCageSigningCertRefResponse {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CageToSigningCert {
-    pub cage_uuid: String,
+pub struct EnclaveToSigningCert {
+    pub enclave_uuid: String,
     pub signing_cert_uuid: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
-pub enum CageState {
+pub enum EnclaveState {
     Pending,
     Active,
     Deleting,
@@ -517,18 +525,18 @@ pub enum CageState {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Cage {
+pub struct Enclave {
     pub uuid: String,
     pub name: String,
     pub team_uuid: String,
     pub app_uuid: String,
     pub domain: String,
-    pub state: CageState,
+    pub state: EnclaveState,
     pub created_at: String,
     pub updated_at: String,
 }
 
-impl Cage {
+impl Enclave {
     pub fn uuid(&self) -> &str {
         &self.uuid
     }
@@ -548,9 +556,9 @@ impl Cage {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CageDeployment {
+pub struct EnclaveDeployment {
     pub uuid: String,
-    pub cage_uuid: String,
+    pub enclave_uuid: String,
     pub version_uuid: String,
     pub signing_cert_uuid: String,
     pub debug_mode: bool,
@@ -558,13 +566,13 @@ pub struct CageDeployment {
     pub completed_at: Option<String>,
 }
 
-impl CageDeployment {
+impl EnclaveDeployment {
     pub fn is_finished(&self) -> bool {
         self.completed_at.is_some()
     }
 
-    pub fn cage_uuid(&self) -> &str {
-        &self.cage_uuid
+    pub fn enclave_uuid(&self) -> &str {
+        &self.enclave_uuid
     }
 
     pub fn uuid(&self) -> &str {
@@ -583,7 +591,7 @@ pub enum BuildStatus {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CageVersion {
+pub struct EnclaveVersion {
     pub uuid: String,
     pub version: u16,
     pub control_plane_img_url: Option<String>,
@@ -597,7 +605,7 @@ pub struct CageVersion {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, PartialOrd)]
 #[serde(rename_all = "camelCase")]
-pub struct CageSigningCert {
+pub struct EnclaveSigningCert {
     pub name: Option<String>,
     pub uuid: String,
     pub app_uuid: String,
@@ -606,7 +614,7 @@ pub struct CageSigningCert {
     pub not_after: Option<String>,
 }
 
-impl CageSigningCert {
+impl EnclaveSigningCert {
     pub fn new(
         name: Option<String>,
         uuid: String,
@@ -661,7 +669,7 @@ pub enum DeployStatus {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CageRegionalDeployment {
+pub struct EnclaveRegionalDeployment {
     pub uuid: String,
     pub deployment_uuid: String,
     pub deployment_order: u16,
@@ -675,7 +683,7 @@ pub struct CageRegionalDeployment {
     pub detailed_status: Option<String>,
 }
 
-impl CageRegionalDeployment {
+impl EnclaveRegionalDeployment {
     pub fn is_failed(&self) -> bool {
         self.deploy_status == DeployStatus::Failed
     }
@@ -695,32 +703,32 @@ impl CageRegionalDeployment {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GetCagesResponse {
-    cages: Vec<Cage>,
+pub struct GetEnclavesResponse {
+    enclaves: Vec<Enclave>,
 }
 
-impl GetCagesResponse {
-    pub fn cages(&self) -> &Vec<Cage> {
-        self.cages.as_ref()
+impl GetEnclavesResponse {
+    pub fn enclaves(&self) -> &Vec<Enclave> {
+        self.enclaves.as_ref()
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DeploymentsForGetCage {
+pub struct DeploymentsForGetEnclave {
     #[serde(flatten)]
-    pub deployment: CageDeployment,
-    #[serde(rename = "teeCageVersion")]
-    pub version: CageVersion,
+    pub deployment: EnclaveDeployment,
+    #[serde(rename = "enclaveVersion")]
+    pub version: EnclaveVersion,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GetCageResponse {
+pub struct GetEnclaveResponse {
     #[serde(flatten)]
-    pub cage: Cage,
-    #[serde(rename = "teeCageDeployments")]
-    pub deployments: Vec<DeploymentsForGetCage>,
+    pub enclaves: Enclave,
+    #[serde(rename = "enclaveDeployments")]
+    pub deployments: Vec<DeploymentsForGetEnclave>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -731,29 +739,29 @@ pub struct GetKeysResponse {
     pub ecdh_key: String,
 }
 
-impl GetCageResponse {
+impl GetEnclaveResponse {
     pub fn is_deleted(&self) -> bool {
-        self.cage.state == CageState::Deleted
+        self.enclaves.state == EnclaveState::Deleted
     }
 
     pub fn domain(&self) -> &str {
-        self.cage.domain.as_str()
+        self.enclaves.domain.as_str()
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GetCageDeploymentResponse {
+pub struct GetEnclaveDeploymentResponse {
     #[serde(flatten)]
-    pub deployment: CageDeployment,
-    pub tee_cage_version: CageVersion,
-    pub tee_cage_signing_cert: CageSigningCert,
-    pub tee_cage_regional_deployments: Vec<CageRegionalDeployment>,
+    pub deployment: EnclaveDeployment,
+    pub tee_enclave_version: EnclaveVersion,
+    pub tee_enclave_signing_cert: EnclaveSigningCert,
+    pub tee_enclave_regional_deployments: Vec<EnclaveRegionalDeployment>,
 }
 
-impl GetCageDeploymentResponse {
+impl GetEnclaveDeploymentResponse {
     pub fn is_built(&self) -> bool {
-        matches!(self.tee_cage_version.build_status, BuildStatus::Ready)
+        matches!(self.tee_enclave_version.build_status, BuildStatus::Ready)
     }
 
     pub fn is_finished(&self) -> bool {
@@ -762,25 +770,25 @@ impl GetCageDeploymentResponse {
 
     //TODO: Handle multi region deployment failures
     pub fn is_failed(&self) -> bool {
-        let build_failed = matches!(self.tee_cage_version.build_status, BuildStatus::Failed);
+        let build_failed = matches!(self.tee_enclave_version.build_status, BuildStatus::Failed);
         build_failed
             || self
-                .tee_cage_regional_deployments
+                .tee_enclave_regional_deployments
                 .first()
                 .map(|depl| depl.is_failed())
                 .unwrap_or_default()
     }
 
     pub fn get_failure_reason(&self) -> Option<String> {
-        self.tee_cage_version.failure_reason.clone().or_else(|| {
-            self.tee_cage_regional_deployments
+        self.tee_enclave_version.failure_reason.clone().or_else(|| {
+            self.tee_enclave_regional_deployments
                 .first()
                 .map(|depl| depl.get_failure_reason())
         })
     }
 
     pub fn get_detailed_status(&self) -> Option<String> {
-        self.tee_cage_regional_deployments
+        self.tee_enclave_regional_deployments
             .first()
             .map(|depl| depl.get_detailed_status())
     }
@@ -789,19 +797,19 @@ impl GetCageDeploymentResponse {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetSigningCertsResponse {
-    pub certs: Vec<CageSigningCert>,
+    pub certs: Vec<EnclaveSigningCert>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CageLogs {
+pub struct EnclaveLogs {
     log_events: Vec<LogEvent>,
     next_token: Option<String>,
     start_time: String,
     end_time: String,
 }
 
-impl CageLogs {
+impl EnclaveLogs {
     pub fn start_time(&self) -> &str {
         &self.start_time
     }
@@ -838,15 +846,15 @@ impl LogEvent {
     }
 }
 
-pub type DeleteCageResponse = Cage;
+pub type DeleteEnclaveResponse = Enclave;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CageScalingConfig {
+pub struct EnclaveScalingConfig {
     limits: ScalingLimits,
     config: ScalingConfig,
 }
 
-impl CageScalingConfig {
+impl EnclaveScalingConfig {
     pub fn max_instances(&self) -> u32 {
         self.limits.max_instances
     }
@@ -881,16 +889,16 @@ impl std::convert::From<u32> for ScalingConfig {
     }
 }
 
-pub type UpdateCageScalingConfigRequest = ScalingConfig;
+pub type UpdateEnclaveScalingConfigRequest = ScalingConfig;
 
 #[cfg(test)]
 mod test {
     use super::*;
 
-    fn get_testing_deployment() -> CageDeployment {
-        CageDeployment {
+    fn get_testing_deployment() -> EnclaveDeployment {
+        EnclaveDeployment {
             uuid: "abc".to_string(),
-            cage_uuid: "def".to_string(),
+            enclave_uuid: "def".to_string(),
             version_uuid: "ghi".to_string(),
             signing_cert_uuid: "jkl".to_string(),
             debug_mode: false,
@@ -899,8 +907,8 @@ mod test {
         }
     }
 
-    fn get_testing_version() -> CageVersion {
-        CageVersion {
+    fn get_testing_version() -> EnclaveVersion {
+        EnclaveVersion {
             uuid: "abc".to_string(),
             version: 1,
             control_plane_img_url: Some("control-plane.com".to_string()),
@@ -913,8 +921,8 @@ mod test {
         }
     }
 
-    fn get_testing_cert() -> CageSigningCert {
-        CageSigningCert {
+    fn get_testing_cert() -> EnclaveSigningCert {
+        EnclaveSigningCert {
             name: Some("abc".to_string()),
             uuid: "abc".to_string(),
             app_uuid: "def".to_string(),
@@ -929,11 +937,11 @@ mod test {
         let deployment = get_testing_deployment();
         let version = get_testing_version();
         let cert = get_testing_cert();
-        let deployment_with_empty_regional = GetCageDeploymentResponse {
+        let deployment_with_empty_regional = GetEnclaveDeploymentResponse {
             deployment,
-            tee_cage_version: version,
-            tee_cage_signing_cert: cert,
-            tee_cage_regional_deployments: vec![],
+            tee_enclave_version: version,
+            tee_enclave_signing_cert: cert,
+            tee_enclave_regional_deployments: vec![],
         };
 
         assert!(deployment_with_empty_regional
@@ -953,11 +961,11 @@ mod test {
 
         let failure_reason = "An error occurred provisioning your TEE".to_string();
         let detailed_failure_reason = "Insufficient capacity".to_string();
-        let deployment_with_regional = GetCageDeploymentResponse {
+        let deployment_with_regional = GetEnclaveDeploymentResponse {
             deployment,
-            tee_cage_version: version,
-            tee_cage_signing_cert: cert,
-            tee_cage_regional_deployments: vec![CageRegionalDeployment {
+            tee_enclave_version: version,
+            tee_enclave_signing_cert: cert,
+            tee_enclave_regional_deployments: vec![EnclaveRegionalDeployment {
                 uuid: "abc".to_string(),
                 deployment_uuid: "def".to_string(),
                 deployment_order: 1,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,6 +1,6 @@
 pub mod assets;
-pub mod cage;
 pub mod client;
+pub mod enclave;
 
 pub use reqwest::Client;
 

--- a/src/attest/error.rs
+++ b/src/attest/error.rs
@@ -8,7 +8,7 @@ pub enum AttestCommandError {
     ReqwestError(#[from] reqwest::Error),
     #[error(transparent)]
     Base64DecodeError(#[from] base64::DecodeError),
-    #[error("Couldn't retrieve attestation document from Cage, status code: {0}")]
+    #[error("Couldn't retrieve attestation document from the Enclave, status code: {0}")]
     AttestationDocRetrievalError(String),
     #[error("The received certificate had no Subject Alt Name extension")]
     NoSubjectAltNames,

--- a/src/attest/mod.rs
+++ b/src/attest/mod.rs
@@ -59,7 +59,7 @@ impl ServerCertVerifier for SubjectAltNameAttestationValidator {
     }
 }
 
-pub async fn attest_connection_to_cage(
+pub async fn attest_connection_to_enclave(
     domain: &str,
     expected_pcrs: PCRs,
 ) -> Result<(), AttestCommandError> {
@@ -121,14 +121,14 @@ mod attest_tests {
     use super::*;
 
     #[tokio::test]
-    async fn connection_to_synthetic_cage_in_debug_mode() {
+    async fn connection_to_synthetic_enclave_in_debug_mode() {
         let expected_pcrs = PCRs {
             pcr_0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(),
             pcr_1: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(),
             pcr_2: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(),
             pcr_8: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(),
         };
-        attest_connection_to_cage(
+        attest_connection_to_enclave(
             "synthetic-cage.app-f5f084041a7e.cage.evervault.com",
             expected_pcrs,
         )
@@ -137,14 +137,14 @@ mod attest_tests {
     }
 
     #[tokio::test]
-    async fn connection_to_synthetic_cage_in_debug_mode_expecting_incorrect_pcrs() {
+    async fn connection_to_synthetic_enclave_in_debug_mode_expecting_incorrect_pcrs() {
         let expected_pcrs = PCRs {
             pcr_0: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(),
             pcr_1: "00000000000different000000000000000000000000PCRs00000000000000000000000000000000000000000000000".to_string(),
             pcr_2: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(),
             pcr_8: "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000".to_string(),
         };
-        let err = attest_connection_to_cage(
+        let err = attest_connection_to_enclave(
             "synthetic-cage.app-f5f084041a7e.cage.evervault.com",
             expected_pcrs,
         )

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -18,8 +18,8 @@ pub enum BuildError {
         "Failed to access dockerfile at {0}. You can specify the dockerfile using the -f flag."
     )]
     DockerfileAccessError(String),
-    #[error("Failed to write the Cage dockerfile to the file system - {0:?}")]
-    FailedToWriteCageDockerfile(std::io::Error),
+    #[error("Failed to write the Enclave dockerfile to the file system - {0:?}")]
+    FailedToWriteEnclaveDockerfile(std::io::Error),
     #[error("An error occurred while building your docker image — {0}")]
     DockerBuildError(String),
     #[error("An error occurred while converting your image to an enclave — {0}")]
@@ -36,7 +36,7 @@ impl CliError for BuildError {
             Self::ContextPathDoesNotExist
             | Self::InvalidSigningInfo(_)
             | Self::DockerfileAccessError(_) => exitcode::NOINPUT,
-            Self::FailedToAccessOutputDir(_) | Self::FailedToWriteCageDockerfile(_) => {
+            Self::FailedToAccessOutputDir(_) | Self::FailedToWriteEnclaveDockerfile(_) => {
                 exitcode::IOERR
             }
             Self::DockerError(_) | Self::DockerBuildError(_) | Self::Utf8Error(_) => {

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -22,7 +22,7 @@ pub enum BuildError {
     FailedToWriteEnclaveDockerfile(std::io::Error),
     #[error("An error occurred while building your docker image — {0}")]
     DockerBuildError(String),
-    #[error("An error occurred while converting your image to an enclave — {0}")]
+    #[error("An error occurred while converting your image to an Enclave — {0}")]
     EnclaveConversionError(String),
     #[error(transparent)]
     EnclaveError(#[from] EnclaveError),

--- a/src/cert/error.rs
+++ b/src/cert/error.rs
@@ -29,7 +29,7 @@ pub enum CertError {
     HashError(String),
     #[error("Failed to parse timestamp")]
     TimstampParseError(#[from] chrono::ParseError),
-    #[error("No certs found for the current Cage.")]
+    #[error("No certs found for the current Enclave.")]
     NoCertsFound,
 }
 

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -10,9 +10,9 @@ use std::path::{Path, PathBuf};
 use x509_parser::parse_x509_certificate;
 use x509_parser::prelude::{parse_x509_pem, X509Certificate};
 
-use crate::api::cage::{
-    CageApi, CageSigningCert, CreateCageSigningCertRefRequest, CreateCageSigningCertRefResponse,
-    UpdateLockedCageSigningCertRequest,
+use crate::api::enclave::{
+    CreateEnclaveSigningCertRefRequest, CreateEnclaveSigningCertRefResponse, EnclaveApi,
+    EnclaveSigningCert, UpdateLockedEnclaveSigningCertRequest,
 };
 use crate::api::{self, AuthMode};
 
@@ -87,25 +87,25 @@ pub async fn upload_new_cert_ref(
     cert_path: &str,
     api_key: &str,
     name: String,
-) -> Result<CreateCageSigningCertRefResponse, CertError> {
+) -> Result<CreateEnclaveSigningCertRefResponse, CertError> {
     let path = std::path::Path::new(cert_path);
 
     let pcr8 = get_cert_pcr(path)?;
     let validity_period = get_cert_validity_period(path)?;
 
-    let cage_api = api::cage::CagesClient::new(AuthMode::ApiKey(api_key.to_string()));
+    let enclave_api = api::enclave::EnclaveClient::new(AuthMode::ApiKey(api_key.to_string()));
 
-    let payload = CreateCageSigningCertRefRequest::new(
+    let payload = CreateEnclaveSigningCertRefRequest::new(
         pcr8.clone(),
         name,
         validity_period.not_before,
         validity_period.not_after,
     );
 
-    let cert_ref = match cage_api.create_cage_signing_cert_ref(payload).await {
+    let cert_ref = match enclave_api.create_enclave_signing_cert_ref(payload).await {
         Ok(cert_ref) => cert_ref,
         Err(e) => {
-            log::error!("Error upload cage signing cert ref — {:?}", e);
+            log::error!("Error upload enclave signing cert ref — {:?}", e);
             return Err(CertError::ApiError(e));
         }
     };
@@ -113,7 +113,7 @@ pub async fn upload_new_cert_ref(
     Ok(cert_ref)
 }
 
-fn format_cert_for_multi_select(cert: &CageSigningCert) -> String {
+fn format_cert_for_multi_select(cert: &EnclaveSigningCert) -> String {
     let name = cert.name().unwrap_or_default();
     let cert_hash = cert.cert_hash();
     let not_after = cert
@@ -143,13 +143,13 @@ fn format_expiry_time(expiry_time: &str) -> Result<String, CertError> {
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 struct CertWithFormattedString {
-    cert: CageSigningCert,
+    cert: EnclaveSigningCert,
     formatted: String,
     locked: bool,
 }
 
 impl CertWithFormattedString {
-    fn new(cert: &CageSigningCert, locked: bool) -> Self {
+    fn new(cert: &EnclaveSigningCert, locked: bool) -> Self {
         Self {
             formatted: format_cert_for_multi_select(cert),
             cert: cert.clone(),
@@ -159,21 +159,24 @@ impl CertWithFormattedString {
 }
 
 async fn get_certs_for_selection(
-    cage_api: api::cage::CagesClient,
-    cage_uuid: &str,
+    enclave_api: api::enclave::EnclaveClient,
+    enclave_uuid: &str,
 ) -> Result<Vec<CertWithFormattedString>, CertError> {
-    let available_certs = match cage_api.get_signing_certs().await {
+    let available_certs = match enclave_api.get_signing_certs().await {
         Ok(res) => res.certs,
         Err(e) => {
-            log::error!("Error getting cage signing cert refs — {:?}", e);
+            log::error!("Error getting enclave signing cert refs — {:?}", e);
             return Err(CertError::ApiError(e));
         }
     };
 
-    let locked_certs = match cage_api.get_cage_locked_signing_certs(cage_uuid).await {
+    let locked_certs = match enclave_api
+        .get_enclave_locked_signing_certs(enclave_uuid)
+        .await
+    {
         Ok(certs) => certs,
         Err(e) => {
-            log::error!("Error getting cage signing cert — {:?}", e);
+            log::error!("Error getting enclave signing cert — {:?}", e);
             return Err(CertError::ApiError(e));
         }
     };
@@ -210,24 +213,24 @@ fn sort_certs_by_expiry(
     Ok(certs)
 }
 
-pub async fn lock_cage_to_certs(
+pub async fn lock_enclave_to_certs(
     api_key: &str,
-    cage_uuid: &str,
-    cage_name: &str,
+    enclave_uuid: &str,
+    enclave_name: &str,
 ) -> Result<(), CertError> {
-    let cage_api = api::cage::CagesClient::new(AuthMode::ApiKey(api_key.to_string()));
+    let enclave_api = api::enclave::EnclaveClient::new(AuthMode::ApiKey(api_key.to_string()));
 
-    let certs_for_select = get_certs_for_selection(cage_api.clone(), cage_uuid).await?;
+    let certs_for_select = get_certs_for_selection(enclave_api.clone(), enclave_uuid).await?;
 
     if certs_for_select.is_empty() {
-        log::error!("No certs found for the current app. You must upload a cert using the `ev cert upload` command or deployment a Cage before you can create a cert lock.");
+        log::error!("No certs found for the current app. You must upload a cert using the `ev cert upload` command or deployment an Enclave before you can create a cert lock.");
         return Err(CertError::NoCertsFound);
     }
 
     let sorted_certs_for_select = sort_certs_by_expiry(certs_for_select)?;
 
     let chosen: Vec<usize> = MultiSelect::new()
-        .with_prompt("Select Certs To Lock Cage To. Press Space To Select, Enter To Confirm.\n Cert Name | PCR8 (Hash of cert) | Cert Expiry ")
+        .with_prompt("Select Certs To Lock Enclave To. Press Space To Select, Enter To Confirm.\n Cert Name | PCR8 (Hash of cert) | Cert Expiry ")
         .report(false)
         .max_length(6)
         .items_checked(
@@ -248,21 +251,21 @@ pub async fn lock_cage_to_certs(
         })
         .collect::<Vec<String>>();
 
-    let payload = UpdateLockedCageSigningCertRequest::new(chosen_cert_uuids.clone());
+    let payload = UpdateLockedEnclaveSigningCertRequest::new(chosen_cert_uuids.clone());
 
     let amount_chosen = chosen_cert_uuids.len();
     let msg = match amount_chosen {
         0 => format!(
-            "No certs selected. Cage {} will not be locked to any certs.",
-            cage_name
+            "No certs selected. Enclave {} will not be locked to any certs.",
+            enclave_name
         ),
         1 => format!(
-            "1 cert selected. Cage {} will be locked to this cert.",
-            cage_name
+            "1 cert selected. Enclave {} will be locked to this cert.",
+            enclave_name
         ),
         _ => format!(
-            "{} certs selected. Cage {} will be locked to these certs",
-            amount_chosen, cage_name
+            "{} certs selected. Enclave {} will be locked to these certs",
+            amount_chosen, enclave_name
         ),
     };
 
@@ -277,20 +280,23 @@ pub async fn lock_cage_to_certs(
         return Ok(());
     }
 
-    if let Err(e) = cage_api
-        .update_cage_locked_signing_certs(cage_uuid, payload)
+    if let Err(e) = enclave_api
+        .update_enclave_locked_signing_certs(enclave_uuid, payload)
         .await
     {
-        log::error!("Error locking Cage to certs - {e}");
+        log::error!("Error locking Enclave to certs - {e}");
         return Err(CertError::ApiError(e));
     };
 
     let final_msg = match amount_chosen {
-        0 => format!("Cage {} successfully unlocked from all certs!", cage_name),
-        1 => format!("Cage {} successfully locked to 1 cert!", cage_name),
+        0 => format!(
+            "Enclave {} successfully unlocked from all certs!",
+            enclave_name
+        ),
+        1 => format!("Enclave {} successfully locked to 1 cert!", enclave_name),
         _ => format!(
-            "Cage {} successfully locked to {} certs!",
-            cage_name, amount_chosen
+            "Enclave {} successfully locked to {} certs!",
+            enclave_name, amount_chosen
         ),
     };
 
@@ -403,10 +409,10 @@ impl<'a> std::default::Default for DistinguishedName<'a> {
     fn default() -> Self {
         Self {
             country: "IE",
-            common_name: "cages.evervault.com",
+            common_name: "enclaves.evervault.com",
             locality: "DUB",
             org: "ENG",
-            org_unit: "CAGES",
+            org_unit: "ENCLAVES",
             state: "LEI",
         }
     }
@@ -491,7 +497,7 @@ mod test {
 
     #[test]
     fn test_sort_certs_by_expiry() {
-        let cert1 = CageSigningCert::new(
+        let cert1 = EnclaveSigningCert::new(
             None,
             "uuid1".to_string(),
             "app_uuid1".to_string(),
@@ -499,7 +505,7 @@ mod test {
             None,
             Some("2023-04-17T12:00:00Z".to_string()),
         );
-        let cert2 = CageSigningCert::new(
+        let cert2 = EnclaveSigningCert::new(
             None,
             "uuid2".to_string(),
             "app_uuid2".to_string(),
@@ -507,7 +513,7 @@ mod test {
             None,
             Some("2023-04-18T12:00:00Z".to_string()),
         );
-        let cert3 = CageSigningCert::new(
+        let cert3 = EnclaveSigningCert::new(
             None,
             "uuid3".to_string(),
             "app_uuid3".to_string(),

--- a/src/cert/mod.rs
+++ b/src/cert/mod.rs
@@ -105,7 +105,7 @@ pub async fn upload_new_cert_ref(
     let cert_ref = match enclave_api.create_enclave_signing_cert_ref(payload).await {
         Ok(cert_ref) => cert_ref,
         Err(e) => {
-            log::error!("Error upload enclave signing cert ref — {:?}", e);
+            log::error!("Error upload Enclave signing cert ref — {:?}", e);
             return Err(CertError::ApiError(e));
         }
     };
@@ -165,7 +165,7 @@ async fn get_certs_for_selection(
     let available_certs = match enclave_api.get_signing_certs().await {
         Ok(res) => res.certs,
         Err(e) => {
-            log::error!("Error getting enclave signing cert refs — {:?}", e);
+            log::error!("Error getting Enclave signing cert refs — {:?}", e);
             return Err(CertError::ApiError(e));
         }
     };
@@ -176,7 +176,7 @@ async fn get_certs_for_selection(
     {
         Ok(certs) => certs,
         Err(e) => {
-            log::error!("Error getting enclave signing cert — {:?}", e);
+            log::error!("Error getting Enclave signing cert — {:?}", e);
             return Err(CertError::ApiError(e));
         }
     };

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -22,11 +22,11 @@ pub struct BuildArgs {
     #[clap(default_value = ".")]
     pub context_path: String,
 
-    /// Certificate used to sign the enclave image file
+    /// Certificate used to sign the Enclave image file
     #[clap(long = "signing-cert")]
     pub certificate: Option<String>,
 
-    /// Private key used to sign the enclave image file
+    /// Private key used to sign the Enclave image file
     #[clap(long = "private-key")]
     pub private_key: Option<String>,
 
@@ -38,7 +38,7 @@ pub struct BuildArgs {
     #[clap(long, from_global)]
     pub json: bool,
 
-    /// Path to directory where the processed dockerfile and enclave will be saved
+    /// Path to directory where the processed dockerfile and Enclave will be saved
     #[clap(short = 'o', long = "output", default_value = ".")]
     pub output_dir: String,
 
@@ -46,7 +46,7 @@ pub struct BuildArgs {
     #[clap(long = "build-arg")]
     pub docker_build_args: Vec<String>,
 
-    /// Path to an enclave dockerfile to build from existing
+    /// Path to an Enclave dockerfile to build from existing
     #[clap(long = "from-existing")]
     pub from_existing: Option<String>,
 
@@ -83,7 +83,7 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         match read_and_validate_config(&build_args.config, &build_args) {
             Ok(config) => config,
             Err(e) => {
-                log::error!("Failed to read enclave config from file system — {e}");
+                log::error!("Failed to read Enclave config from file system — {e}");
                 return e.exitcode();
             }
         };
@@ -131,7 +131,7 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
     {
         Ok((built_enclave, _)) => built_enclave,
         Err(e) => {
-            log::error!("An error occurred while building your enclave — {e}");
+            log::error!("An error occurred while building your Enclave — {e}");
             return e.exitcode();
         }
     };
@@ -144,7 +144,7 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         crate::common::log_debug_mode_attestation_warning();
     }
 
-    // Write enclave measures to stdout
+    // Write Enclave measures to stdout
     let success_msg = serde_json::json!({
         "status": "success",
         "message": "EIF built successfully",

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -6,15 +6,15 @@ use crate::docker::command::get_source_date_epoch;
 use crate::version::check_version;
 use clap::Parser;
 
-/// Build a Cage from a Dockerfile
+/// Build an Enclave from a Dockerfile
 #[derive(Parser, Debug)]
 #[clap(name = "build", about)]
 pub struct BuildArgs {
-    /// Path to cage.toml config file. This can be generated using the init command
-    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    /// Path to enclave.toml config file. This can be generated using the init command
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
     pub config: String,
 
-    /// Path to Dockerfile for Cage. Will override any dockerfile specified in the .toml file.
+    /// Path to Dockerfile for Enclave. Will override any dockerfile specified in the .toml file.
     #[clap(short = 'f', long = "file")]
     pub dockerfile: Option<String>,
 
@@ -79,11 +79,11 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         return exitcode::SOFTWARE;
     };
 
-    let (mut cage_config, validated_config) =
+    let (mut enclave_config, validated_config) =
         match read_and_validate_config(&build_args.config, &build_args) {
             Ok(config) => config,
             Err(e) => {
-                log::error!("Failed to read cage config from file system — {e}");
+                log::error!("Failed to read enclave config from file system — {e}");
                 return e.exitcode();
             }
         };
@@ -93,8 +93,8 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         .as_ref()
         .map(|args| args.iter().map(AsRef::as_ref).collect());
 
-    let cage_build_assets_client = AssetsClient::new();
-    let data_plane_version = match cage_build_assets_client.get_data_plane_version().await {
+    let enclave_build_assets_client = AssetsClient::new();
+    let data_plane_version = match enclave_build_assets_client.get_data_plane_version().await {
         Ok(version) => version,
         Err(e) => {
             log::error!("Failed to retrieve the latest data plane version - {e:?}");
@@ -102,7 +102,7 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         }
     };
 
-    let installer_version = match cage_build_assets_client.get_installer_version().await {
+    let installer_version = match enclave_build_assets_client.get_installer_version().await {
         Ok(version) => version,
         Err(e) => {
             log::error!("Failed to retrieve the latest installer version - {e:?}");
@@ -136,11 +136,11 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         }
     };
 
-    cage_config.set_attestation(built_enclave.measurements());
-    cage_config.set_runtime_info(runtime_info);
-    crate::common::save_cage_config(&cage_config, &build_args.config);
+    enclave_config.set_attestation(built_enclave.measurements());
+    enclave_config.set_runtime_info(runtime_info);
+    crate::common::save_enclave_config(&enclave_config, &build_args.config);
 
-    if cage_config.debug {
+    if enclave_config.debug {
         crate::common::log_debug_mode_attestation_warning();
     }
 

--- a/src/cli/cert.rs
+++ b/src/cli/cert.rs
@@ -20,10 +20,10 @@ pub enum CertCommands {
     /// Create a new Enclave signing certificate
     #[clap()]
     New(NewCertArgs),
-    /// Upload a enclave signing certificate's metadata to Evervault
+    /// Upload a Enclave signing certificate's metadata to Evervault
     #[clap()]
     Upload(UploadCertArgs),
-    /// Lock a enclave to specific signing certificate. Enclave deployment will fail if the signing certificate is not the one specified.
+    /// Lock a Enclave to specific signing certificate. Enclave deployment will fail if the signing certificate is not the one specified.
     #[clap()]
     Lock(LockCertArgs),
 }
@@ -157,12 +157,12 @@ pub async fn run(cert_args: CertArgs) -> exitcode::ExitCode {
                     Ok(enclave_config) => match (enclave_config.uuid, enclave_config.name) {
                         (Some(uuid), name) => (uuid, name),
                         _ => {
-                            log::error!("No enclave details found in enclave.toml");
+                            log::error!("No Enclave details found in enclave.toml");
                             return DATAERR;
                         }
                     },
                     Err(_) => {
-                        log::error!("Failed to load enclave configuration");
+                        log::error!("Failed to load Enclave configuration");
                         return DATAERR;
                     }
                 };

--- a/src/cli/delete.rs
+++ b/src/cli/delete.rs
@@ -1,26 +1,26 @@
 use crate::common::CliError;
-use crate::delete::delete_cage;
+use crate::delete::delete_enclave;
 use crate::get_api_key;
 use crate::version::check_version;
 use clap::Parser;
 
-/// Delete a Cage from a toml file.
+/// Delete an Enclave from a toml file.
 #[derive(Debug, Parser)]
 #[clap(name = "delete", about)]
 pub struct DeleteArgs {
-    /// Path to cage.toml config file
-    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    /// Path to enclave.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
     pub config: String,
 
-    /// Uuid of the Cage to delete
-    #[clap(long = "cage-uuid")]
-    pub cage_uuid: Option<String>,
+    /// Uuid of the Enclave to delete
+    #[clap(long = "enclave-uuid")]
+    pub enclave_uuid: Option<String>,
 
     /// Disable verbose output
     #[clap(long)]
     pub quiet: bool,
 
-    /// Perform the Cage deletion in the background
+    /// Perform the Enclave deletion in the background
     #[clap(long)]
     pub background: bool,
 
@@ -34,13 +34,13 @@ pub async fn run(delete_args: DeleteArgs) -> exitcode::ExitCode {
         return exitcode::SOFTWARE;
     };
     let should_del = match dialoguer::Confirm::new()
-        .with_prompt("Are you sure you want to delete this Cage?")
+        .with_prompt("Are you sure you want to delete this Enclave?")
         .default(false)
         .interact()
     {
         Ok(should_delete) => should_delete,
         Err(_) => {
-            log::error!("An error occurred while attempting to confirm this Cage delete.");
+            log::error!("An error occurred while attempting to confirm this Enclave delete.");
             return exitcode::IOERR;
         }
     };
@@ -51,9 +51,9 @@ pub async fn run(delete_args: DeleteArgs) -> exitcode::ExitCode {
     }
 
     let api_key = get_api_key!();
-    match delete_cage(
+    match delete_enclave(
         delete_args.config.as_str(),
-        delete_args.cage_uuid.as_deref(),
+        delete_args.enclave_uuid.as_deref(),
         api_key.as_str(),
         delete_args.background,
     )
@@ -61,7 +61,7 @@ pub async fn run(delete_args: DeleteArgs) -> exitcode::ExitCode {
     {
         Ok(_) => {
             if delete_args.background {
-                log::info!("Cage successfully marked for deletion.");
+                log::info!("Enclave successfully marked for deletion.");
             } else {
                 log::info!("Deletion was successful");
             }

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -35,11 +35,11 @@ pub struct DeployArgs {
     #[clap(default_value = ".")]
     pub context_path: String,
 
-    /// Certificate used to sign the enclave image file
+    /// Certificate used to sign the Enclave image file
     #[clap(long = "signing-cert")]
     pub certificate: Option<String>,
 
-    /// Private key used to sign the enclave image file
+    /// Private key used to sign the Enclave image file
     #[clap(long = "private-key")]
     pub private_key: Option<String>,
 
@@ -51,7 +51,7 @@ pub struct DeployArgs {
     #[clap(long = "build-arg")]
     pub docker_build_args: Vec<String>,
 
-    /// Path to an enclave dockerfile to build from existing
+    /// Path to an Enclave dockerfile to build from existing
     #[clap(long = "from-existing")]
     pub from_existing: Option<String>,
 

--- a/src/cli/encrypt.rs
+++ b/src/cli/encrypt.rs
@@ -1,6 +1,6 @@
 use crate::version::check_version;
 use crate::{
-    config::CageConfig,
+    config::EnclaveConfig,
     encrypt::{self, EncryptError},
 };
 use clap::Parser;
@@ -30,8 +30,8 @@ pub struct EncryptArgs {
     #[clap(long = "app_uuid")]
     pub app_uuid: Option<String>,
 
-    /// Path to cage.toml config file
-    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    /// Path to enclave.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
     pub config: String,
 }
 
@@ -41,7 +41,7 @@ pub async fn run(encrypt_args: EncryptArgs) -> exitcode::ExitCode {
         return exitcode::SOFTWARE;
     };
 
-    let (team_uuid, app_uuid) = match get_cage_details(encrypt_args.clone()) {
+    let (team_uuid, app_uuid) = match get_enclave_details(encrypt_args.clone()) {
         Ok((team_uuid, app_uuid)) => (team_uuid, app_uuid),
         Err(e) => {
             log::error!("Config error {e}");
@@ -60,16 +60,16 @@ pub async fn run(encrypt_args: EncryptArgs) -> exitcode::ExitCode {
     }
 }
 
-fn get_cage_details(encrypt_args: EncryptArgs) -> Result<(String, String), EncryptError> {
+fn get_enclave_details(encrypt_args: EncryptArgs) -> Result<(String, String), EncryptError> {
     if encrypt_args.team_uuid.is_none() || encrypt_args.app_uuid.is_none() {
-        let cage_config = CageConfig::try_from_filepath(&encrypt_args.config)?;
+        let enclave_config = EnclaveConfig::try_from_filepath(&encrypt_args.config)?;
 
-        if cage_config.app_uuid.is_none() || cage_config.team_uuid.is_none() {
+        if enclave_config.app_uuid.is_none() || enclave_config.team_uuid.is_none() {
             Err(EncryptError::MissingUuid)
         } else {
             Ok((
-                cage_config.team_uuid.unwrap(),
-                cage_config.app_uuid.unwrap(),
+                enclave_config.team_uuid.unwrap(),
+                enclave_config.app_uuid.unwrap(),
             ))
         }
     } else {

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -2,7 +2,7 @@ use crate::version::check_version;
 use clap::{Parser, Subcommand};
 
 use crate::{
-    api::{cage::CagesClient, AuthMode},
+    api::{enclave::EnclaveClient, AuthMode},
     get_api_key,
 };
 
@@ -16,7 +16,7 @@ pub enum EnvAction {
     Get,
 }
 
-/// Manage Cage environment
+/// Manage Enclave environment
 #[derive(Debug, Parser)]
 #[clap(name = "cert", about)]
 pub struct EnvArgs {
@@ -27,15 +27,15 @@ pub struct EnvArgs {
 #[derive(Debug, Subcommand)]
 pub enum EnvCommands {
     #[clap()]
-    /// Add Cage environment variable
+    /// Add Enclave environment variable
     Add(AddEnvArgs),
-    /// Delete Cage environment variable
+    /// Delete Enclave environment variable
     Delete(DeleteEnvArgs),
-    /// Get Cage environment variables
+    /// Get Enclave environment variables
     Get(GetEnvArgs),
 }
 
-/// Add secret to Cage env
+/// Add secret to Enclave env
 #[derive(Debug, Parser)]
 #[clap(name = "env", about)]
 pub struct AddEnvArgs {
@@ -55,12 +55,12 @@ pub struct AddEnvArgs {
     #[clap(arg_enum, default_value = "nist")]
     pub curve: CurveName,
 
-    /// Path to cage.toml config file
-    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    /// Path to enclave.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
     pub config: String,
 }
 
-/// Add delete secret from Cage env
+/// Add delete secret from Enclave env
 #[derive(Debug, Parser)]
 #[clap(name = "env", about)]
 pub struct DeleteEnvArgs {
@@ -68,17 +68,17 @@ pub struct DeleteEnvArgs {
     #[clap(long = "key")]
     pub name: String,
 
-    /// Path to cage.toml config file
-    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    /// Path to enclave.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
     pub config: String,
 }
 
-/// Get secrets from Cage env
+/// Get secrets from Enclave env
 #[derive(Debug, Parser)]
 #[clap(name = "env", about)]
 pub struct GetEnvArgs {
-    /// Path to cage.toml config file
-    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    /// Path to enclave.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
     pub config: String,
 }
 
@@ -89,9 +89,9 @@ pub async fn run(env_args: EnvArgs) -> exitcode::ExitCode {
     };
 
     let api_key = get_api_key!();
-    let cages_client = CagesClient::new(AuthMode::ApiKey(api_key));
+    let enclave_client = EnclaveClient::new(AuthMode::ApiKey(api_key));
 
-    match env(cages_client, env_args.action).await {
+    match env(enclave_client, env_args.action).await {
         Ok(result) => match result {
             Some(env) => {
                 let success_msg = serde_json::json!(env);

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -70,7 +70,7 @@ pub struct InitArgs {
     #[clap(long = "self-destruct")]
     pub is_time_bound: bool,
 
-    /// Comma separated list of destinations to allow traffic to from the enclave e.g api.evervault.com, default is allow all
+    /// Comma separated list of destinations to allow traffic to from the Enclave e.g api.evervault.com, default is allow all
     #[clap(long = "egress-destinations")]
     pub egress_destinations: Option<String>,
 
@@ -169,7 +169,7 @@ async fn init_local_config(init_args: InitArgs, created_enclave: Enclave) -> exi
                 initial_config.set_key(format!("{}", key_path.display()));
             }
             Err(e) => {
-                log::error!("Failed to generate enclave signing credentials - {e}");
+                log::error!("Failed to generate Enclave signing credentials - {e}");
                 return e.exitcode();
             }
         }

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -28,7 +28,7 @@ pub enum ListCommands {
 
 #[derive(Debug, Parser)]
 pub struct DeploymentArgs {
-    /// The enclave uuid to get deployments for
+    /// The Enclave uuid to get deployments for
     #[clap(long = "enclave-uuid")]
     enclave_uuid: Option<String>,
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,11 +1,11 @@
-use crate::api::{cage::CageApi, AuthMode};
+use crate::api::{enclave::EnclaveApi, AuthMode};
 use crate::common::CliError;
 use crate::config::{read_and_validate_config, BuildTimeConfig};
 use crate::version::check_version;
 use crate::{api, get_api_key};
 use clap::Parser;
 
-/// List your Cages and Deployments
+/// List your Enclaves and Deployments
 #[derive(Debug, Parser)]
 #[clap(name = "list", about)]
 pub struct List {
@@ -18,22 +18,22 @@ pub struct List {
 #[derive(Debug, Parser)]
 #[clap(name = "list", about)]
 pub enum ListCommands {
-    /// List Cages
+    /// List Enclaves
     #[clap()]
-    Cages,
-    /// List Cage Deployments
+    Enclaves,
+    /// List Enclave Deployments
     #[clap()]
     Deployments(DeploymentArgs),
 }
 
 #[derive(Debug, Parser)]
 pub struct DeploymentArgs {
-    /// The cage uuid to get deployments for
-    #[clap(long = "cage-uuid")]
-    cage_uuid: Option<String>,
+    /// The enclave uuid to get deployments for
+    #[clap(long = "enclave-uuid")]
+    enclave_uuid: Option<String>,
 
-    /// The file containing the Cage config
-    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    /// The file containing the Enclave config
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
     config: String,
 }
 impl BuildTimeConfig for DeploymentArgs {}
@@ -47,42 +47,42 @@ pub async fn run(list_action: List) -> exitcode::ExitCode {
     let api_key = get_api_key!();
     let auth = AuthMode::ApiKey(api_key);
 
-    let cage_client = api::cage::CagesClient::new(auth);
+    let enclave_client = api::enclave::EnclaveClient::new(auth);
 
     match list_action.resource {
-        ListCommands::Cages => list_cages(&cage_client).await,
+        ListCommands::Enclaves => list_enclaves(&enclave_client).await,
         ListCommands::Deployments(deployment_args) => {
-            list_deployments(&cage_client, deployment_args).await
+            list_deployments(&enclave_client, deployment_args).await
         }
     }
 }
 
-async fn list_cages(cage_client: &api::cage::CagesClient) -> exitcode::ExitCode {
-    let cages = match cage_client.get_cages().await {
-        Ok(cages) => cages,
+async fn list_enclaves(enclave_client: &api::enclave::EnclaveClient) -> exitcode::ExitCode {
+    let enclaves = match enclave_client.get_enclaves().await {
+        Ok(enclaves) => enclaves,
         Err(e) => {
-            log::error!("An error occurred while retrieving your Cages — {:?}", e);
+            log::error!("An error occurred while retrieving your Enclaves — {:?}", e);
             return e.exitcode();
         }
     };
 
-    let serialized_cages = serde_json::to_string_pretty(&cages).unwrap();
-    println!("{}", serialized_cages);
+    let serialized_enclaves = serde_json::to_string_pretty(&enclaves).unwrap();
+    println!("{}", serialized_enclaves);
     exitcode::OK
 }
 
 async fn list_deployments(
-    cage_client: &api::cage::CagesClient,
+    enclave_client: &api::enclave::EnclaveClient,
     deployment_args: DeploymentArgs,
 ) -> exitcode::ExitCode {
-    let cage_uuid = if let Some(uuid) = deployment_args.cage_uuid.clone() {
+    let enclave_uuid = if let Some(uuid) = deployment_args.enclave_uuid.clone() {
         uuid
     } else {
         match read_and_validate_config(&deployment_args.config, &deployment_args) {
-            Ok((_, validated_config)) => validated_config.cage_uuid().to_string(),
+            Ok((_, validated_config)) => validated_config.enclave_uuid().to_string(),
             Err(e) => {
                 log::error!(
-                    "No Cage uuid provided, and failed to parse the Cage config - {}",
+                    "No Enclave uuid provided, and failed to parse the Enclave config - {}",
                     e
                 );
                 return e.exitcode();
@@ -90,15 +90,15 @@ async fn list_deployments(
         }
     };
 
-    let cages = match cage_client.get_cage(&cage_uuid).await {
-        Ok(cages) => cages,
+    let enclave = match enclave_client.get_enclave(&enclave_uuid).await {
+        Ok(enclave) => enclave,
         Err(e) => {
-            log::error!("An error occurred while retrieving your Cages — {:?}", e);
+            log::error!("An error occurred while retrieving your Enclaves — {:?}", e);
             return e.exitcode();
         }
     };
 
-    let serialized_deployments = serde_json::to_string_pretty(&cages).unwrap();
+    let serialized_deployments = serde_json::to_string_pretty(&enclave).unwrap();
     println!("{}", serialized_deployments);
     exitcode::OK
 }

--- a/src/cli/restart.rs
+++ b/src/cli/restart.rs
@@ -1,27 +1,27 @@
 use crate::version::check_version;
 use crate::{
-    api::{cage::CagesClient, AuthMode},
+    api::{enclave::EnclaveClient, AuthMode},
     common::CliError,
     deploy::{timed_operation, watch_deployment, DEPLOY_WATCH_TIMEOUT_SECONDS},
     get_api_key,
     progress::get_tracker,
-    restart::restart_cage,
+    restart::restart_enclave,
 };
 use clap::Parser;
 
-/// Restart the Cage deployment
+/// Restart the Enclave deployment
 #[derive(Debug, Parser)]
 #[clap(name = "restart", about)]
 pub struct RestartArgs {
-    /// Path to cage.toml config file
-    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    /// Path to enclave.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
     pub config: String,
 
-    /// Uuid of the Cage who's deployment to restart
-    #[clap(long = "cage-uuid")]
-    pub cage_uuid: Option<String>,
+    /// Uuid of the Enclave who's deployment to restart
+    #[clap(long = "enclave-uuid")]
+    pub enclave_uuid: Option<String>,
 
-    /// Perform the Cage restart in the background
+    /// Perform the Enclave restart in the background
     #[clap(long)]
     pub background: bool,
 }
@@ -34,12 +34,12 @@ pub async fn run(restart_args: RestartArgs) -> i32 {
 
     let api_key = get_api_key!();
 
-    let cage_api = CagesClient::new(AuthMode::ApiKey(api_key.to_string()));
+    let enclave_api = EnclaveClient::new(AuthMode::ApiKey(api_key.to_string()));
 
-    let new_deployment = match restart_cage(
+    let new_deployment = match restart_enclave(
         restart_args.config.as_str(),
-        restart_args.cage_uuid.as_deref(),
-        &cage_api,
+        restart_args.enclave_uuid.as_deref(),
+        &enclave_api,
         restart_args.background,
     )
     .await
@@ -52,21 +52,23 @@ pub async fn run(restart_args: RestartArgs) -> i32 {
     };
 
     if restart_args.background {
-        println!("Cage restarting. You can observe the restart progress in the Cages Dashboard");
+        println!(
+            "Enclave restarting. You can observe the restart progress in the Enclaves Dashboard"
+        );
         return exitcode::OK;
     }
 
     let progress_bar = get_tracker(
-        "Deploying Cage into a Trusted Execution Environment...",
+        "Deploying Enclave into a Trusted Execution Environment...",
         None,
     );
 
     match timed_operation(
-        "Cage Deployment",
+        "Enclave Deployment",
         DEPLOY_WATCH_TIMEOUT_SECONDS,
         watch_deployment(
-            cage_api,
-            new_deployment.cage_uuid(),
+            enclave_api,
+            new_deployment.enclave_uuid(),
             new_deployment.uuid(),
             progress_bar,
         ),

--- a/src/cli/scale.rs
+++ b/src/cli/scale.rs
@@ -2,11 +2,11 @@ use crate::config::{self, ScalingSettings};
 use crate::version::check_version;
 use crate::{
     api::{
-        cage::{CageApi, CagesClient},
+        enclave::{EnclaveApi, EnclaveClient},
         AuthMode,
     },
     common::CliError,
-    config::CageConfig,
+    config::EnclaveConfig,
     get_api_key,
 };
 use clap::Parser;
@@ -14,10 +14,10 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ScaleError {
-    #[error("No Cage Uuid given. You can provide one by using either the --cage-uuid flag, or using the --config flag to point to a Cage.toml")]
+    #[error("No Enclave Uuid given. You can provide one by using either the --enclave-uuid flag, or using the --config flag to point to an Enclave.toml")]
     MissingUuid,
-    #[error("An error occurred parsing the Cage config - {0}")]
-    ConfigError(#[from] config::CageConfigError),
+    #[error("An error occurred parsing the Enclave config - {0}")]
+    ConfigError(#[from] config::EnclaveConfigError),
     #[error("An error occurred contacting the API — {0}")]
     ApiError(#[from] crate::api::client::ApiError),
 }
@@ -32,23 +32,23 @@ impl CliError for ScaleError {
     }
 }
 
-/// Update your Cage's Scaling config
+/// Update your Enclave's Scaling config
 #[derive(Debug, Parser)]
 #[clap(name = "scale", about)]
 pub struct ScaleArgs {
-    /// Path to cage.toml config file
-    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    /// Path to enclave.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
     pub config: String,
 
-    /// Uuid of the Cage to scale
-    #[clap(long = "cage-uuid")]
-    pub cage_uuid: Option<String>,
+    /// Uuid of the Enclave to scale
+    #[clap(long = "enclave-uuid")]
+    pub enclave_uuid: Option<String>,
 
-    /// Number of replicas to run for this Cage. If unset, the command will read the current scaling config from the Evervault API.
+    /// Number of replicas to run for this Enclave. If unset, the command will read the current scaling config from the Evervault API.
     #[clap(long = "desired-replicas")]
     pub desired_replicas: Option<u32>,
 
-    /// Sync the local Cage.toml with the latest scaling config for a Cage if they differ.
+    /// Sync the local Enclave.toml with the latest scaling config for an Enclave if they differ.
     #[clap(long = "sync")]
     pub sync: bool,
 }
@@ -61,22 +61,25 @@ pub async fn run(args: ScaleArgs) -> i32 {
 
     let api_key = get_api_key!();
 
-    let cage_api = CagesClient::new(AuthMode::ApiKey(api_key.to_string()));
+    let enclave_api = EnclaveClient::new(AuthMode::ApiKey(api_key.to_string()));
 
-    let cage_config = CageConfig::try_from_filepath(&args.config);
-    let cage_uuid = match args.cage_uuid.as_deref() {
-        Some(cage_uuid) => Ok(cage_uuid),
-        None => match cage_config.as_ref() {
-            Ok(cage_config) => cage_config.uuid.as_deref().ok_or(ScaleError::MissingUuid),
+    let enclave_config = EnclaveConfig::try_from_filepath(&args.config);
+    let enclave_uuid = match args.enclave_uuid.as_deref() {
+        Some(enclave_uuid) => Ok(enclave_uuid),
+        None => match enclave_config.as_ref() {
+            Ok(enclave_config) => enclave_config
+                .uuid
+                .as_deref()
+                .ok_or(ScaleError::MissingUuid),
             Err(e) => {
-                log::error!("Failed to resolve cage config - {e:?}");
+                log::error!("Failed to resolve enclave config - {e:?}");
                 return e.exitcode();
             }
         },
     };
 
-    let cage_uuid = match cage_uuid {
-        Ok(cage_uuid) => cage_uuid,
+    let enclave_uuid = match enclave_uuid {
+        Ok(enclave_uuid) => enclave_uuid,
         Err(e) => {
             log::error!("{e:?}");
             return e.exitcode();
@@ -86,16 +89,16 @@ pub async fn run(args: ScaleArgs) -> i32 {
     let scaling_config_result = match args.desired_replicas {
         Some(new_desired_replicas) => {
             log::info!("Updating desired replicas to {new_desired_replicas}");
-            cage_api
-                .update_scaling_config(cage_uuid, new_desired_replicas.into())
+            enclave_api
+                .update_scaling_config(enclave_uuid, new_desired_replicas.into())
                 .await
         }
-        None => cage_api.get_scaling_config(cage_uuid).await,
+        None => enclave_api.get_scaling_config(enclave_uuid).await,
     };
 
     let scaling_config = match scaling_config_result {
         Ok(result) if args.desired_replicas.is_some() => {
-            log::info!("Cage scaling config updated successfully");
+            log::info!("Enclave scaling config updated successfully");
             result
         }
         Ok(result) => result,
@@ -105,12 +108,12 @@ pub async fn run(args: ScaleArgs) -> i32 {
             } else {
                 "read"
             };
-            log::error!("Failed to {action} the scaling config for {cage_uuid} - {e:?}");
+            log::error!("Failed to {action} the scaling config for {enclave_uuid} - {e:?}");
             return e.exitcode();
         }
     };
 
-    if let Ok(mut config) = cage_config {
+    if let Ok(mut config) = enclave_config {
         let has_scaling_drift = config
             .scaling
             .as_ref()
@@ -122,7 +125,7 @@ pub async fn run(args: ScaleArgs) -> i32 {
             config.set_scaling_config(ScalingSettings {
                 desired_replicas: scaling_config.desired_replicas(),
             });
-            crate::common::save_cage_config(&config, &args.config);
+            crate::common::save_enclave_config(&config, &args.config);
         }
     }
 

--- a/src/cli/scale.rs
+++ b/src/cli/scale.rs
@@ -72,7 +72,7 @@ pub async fn run(args: ScaleArgs) -> i32 {
                 .as_deref()
                 .ok_or(ScaleError::MissingUuid),
             Err(e) => {
-                log::error!("Failed to resolve enclave config - {e:?}");
+                log::error!("Failed to resolve Enclave config - {e:?}");
                 return e.exitcode();
             }
         },

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -73,7 +73,7 @@ pub async fn run(args: UpdateArgs) -> exitcode::ExitCode {
 
     let result = std::process::Command::new("sh")
         .arg(tempfile.path())
-        .env("CAGE_CLI_FORCE_INSTALL", "true")
+        .env("CLI_FORCE_INSTALL", "true")
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
         .status();
@@ -81,7 +81,7 @@ pub async fn run(args: UpdateArgs) -> exitcode::ExitCode {
     match result {
         Ok(output) => output.code().unwrap_or(exitcode::USAGE),
         Err(e) => {
-            log::error!("Failed to install latest version of Cages CLI - {}", e);
+            log::error!("Failed to install latest version of Enclaves CLI - {}", e);
             exitcode::SOFTWARE
         }
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,7 +2,7 @@ use std::ffi::OsStr;
 use std::path::PathBuf;
 use thiserror::Error;
 
-use crate::config::{CageConfig, CageConfigError};
+use crate::config::{EnclaveConfig, EnclaveConfigError};
 
 pub struct OutputPath {
     _tmp_dir: Option<tempfile::TempDir>,
@@ -71,19 +71,19 @@ pub fn resolve_output_path(
     }
 }
 
-pub fn save_cage_config(cage_config: &CageConfig, config_path: &str) {
-    if let Ok(serialized_config) = toml::ser::to_vec(&cage_config) {
+pub fn save_enclave_config(enclave_config: &EnclaveConfig, config_path: &str) {
+    if let Ok(serialized_config) = toml::ser::to_vec(&enclave_config) {
         match std::fs::write(config_path, serialized_config) {
-            Ok(_) => log::debug!("Cage config updated"),
-            Err(e) => log::error!("Failed to update cage config — {e:?}"),
+            Ok(_) => log::debug!("Enclave config updated"),
+            Err(e) => log::error!("Failed to update enclave config — {e:?}"),
         };
     } else {
-        log::error!("Failed to serialize attestation measures in cage config");
+        log::error!("Failed to serialize attestation measures in enclave config");
     }
 }
 
 pub fn log_debug_mode_attestation_warning() {
-    log::warn!("When running your Cage in debug mode, every value in the attestation document returned will be 0.");
+    log::warn!("When running your Enclave in debug mode, every value in the attestation document returned will be 0.");
     log::warn!("The measurements below will only be returned when running in non-debug mode.");
 }
 
@@ -122,14 +122,14 @@ pub fn prepare_build_args(build_args: &Vec<String>) -> Option<Vec<String>> {
     Some(formatted_args)
 }
 
-pub fn resolve_cage_uuid(
+pub fn resolve_enclave_uuid(
     given_uuid: Option<&str>,
     config_path: &str,
-) -> Result<Option<String>, CageConfigError> {
+) -> Result<Option<String>, EnclaveConfigError> {
     if let Some(given_uuid) = given_uuid {
         return Ok(Some(given_uuid.to_string()));
     }
-    let config = CageConfig::try_from_filepath(config_path)?;
+    let config = EnclaveConfig::try_from_filepath(config_path)?;
     Ok(config.uuid)
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -75,10 +75,10 @@ pub fn save_enclave_config(enclave_config: &EnclaveConfig, config_path: &str) {
     if let Ok(serialized_config) = toml::ser::to_vec(&enclave_config) {
         match std::fs::write(config_path, serialized_config) {
             Ok(_) => log::debug!("Enclave config updated"),
-            Err(e) => log::error!("Failed to update enclave config — {e:?}"),
+            Err(e) => log::error!("Failed to update Enclave config — {e:?}"),
         };
     } else {
-        log::error!("Failed to serialize attestation measures in enclave config");
+        log::error!("Failed to serialize attestation measures in Enclave config");
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,28 +188,28 @@ impl std::convert::TryFrom<&ValidatedSigningInfo> for EnclaveSigningInfo {
 }
 
 #[derive(Debug, Error)]
-pub enum CageConfigError {
+pub enum EnclaveConfigError {
     #[error("Failed to find config file at {0}")]
     MissingConfigFile(String),
     #[error("Failed to read config file — {0:?}")]
     FailedToAccessConfig(#[from] std::io::Error),
-    #[error("Failed to parse Cage config")]
-    FailedToParseCageConfig(#[from] toml::de::Error),
+    #[error("Failed to parse Enclave config")]
+    FailedToParseEnclaveConfig(#[from] toml::de::Error),
     #[error("{0}. Signing credentials can be generated using the cert new command.")]
     MissingSigningInfo(#[from] SigningInfoError),
     #[error("Dockerfile is required and was not given.")]
     MissingDockerfile,
     #[error("{0} was not set in the toml.")]
     MissingField(String),
-    #[error("TLS Termination must be enabled to enable cage logging.")]
+    #[error("TLS Termination must be enabled to enable enclave logging.")]
     LoggingEnabledWithoutTLSTermination(),
 }
 
-impl CliError for CageConfigError {
+impl CliError for EnclaveConfigError {
     fn exitcode(&self) -> exitcode::ExitCode {
         match self {
             Self::MissingConfigFile(_) | Self::FailedToAccessConfig(_) => exitcode::NOINPUT,
-            Self::FailedToParseCageConfig(_)
+            Self::FailedToParseEnclaveConfig(_)
             | Self::MissingDockerfile
             | Self::MissingField(_)
             | Self::LoggingEnabledWithoutTLSTermination() => exitcode::DATAERR,
@@ -227,7 +227,7 @@ pub fn default_true() -> bool {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CageConfig {
+pub struct EnclaveConfig {
     pub name: String,
     pub uuid: Option<String>,
     pub app_uuid: Option<String>,
@@ -255,15 +255,15 @@ pub struct CageConfig {
     pub runtime: Option<RuntimeVersions>,
 }
 
-impl CageConfig {
-    pub fn annotate(&mut self, cage: crate::api::cage::Cage) {
-        self.uuid = Some(cage.uuid().into());
-        self.app_uuid = Some(cage.app_uuid().into());
-        self.team_uuid = Some(cage.team_uuid().into());
+impl EnclaveConfig {
+    pub fn annotate(&mut self, enclave: crate::api::enclave::Enclave) {
+        self.uuid = Some(enclave.uuid().into());
+        self.app_uuid = Some(enclave.app_uuid().into());
+        self.team_uuid = Some(enclave.team_uuid().into());
     }
 }
 
-impl std::convert::AsRef<CageConfig> for CageConfig {
+impl std::convert::AsRef<EnclaveConfig> for EnclaveConfig {
     fn as_ref(&self) -> &Self {
         self
     }
@@ -271,9 +271,9 @@ impl std::convert::AsRef<CageConfig> for CageConfig {
 
 // Helper type to guarantee the presence of fields when combining multiple config sources
 #[derive(Clone, Debug)]
-pub struct ValidatedCageBuildConfig {
-    pub cage_name: String,
-    pub cage_uuid: String,
+pub struct ValidatedEnclaveBuildConfig {
+    pub enclave_name: String,
+    pub enclave_uuid: String,
     pub app_uuid: String,
     pub team_uuid: String,
     pub debug: bool,
@@ -291,7 +291,7 @@ pub struct ValidatedCageBuildConfig {
     pub healthcheck: Option<String>,
 }
 
-impl ValidatedCageBuildConfig {
+impl ValidatedEnclaveBuildConfig {
     pub fn signing_info(&self) -> &ValidatedSigningInfo {
         &self.signing
     }
@@ -304,12 +304,12 @@ impl ValidatedCageBuildConfig {
         &self.egress
     }
 
-    pub fn cage_name(&self) -> &str {
-        &self.cage_name
+    pub fn enclave_name(&self) -> &str {
+        &self.enclave_name
     }
 
-    pub fn cage_uuid(&self) -> &str {
-        &self.cage_uuid
+    pub fn enclave_uuid(&self) -> &str {
+        &self.enclave_uuid
     }
 
     pub fn app_uuid(&self) -> &str {
@@ -359,7 +359,7 @@ impl ValidatedCageBuildConfig {
     }
 }
 
-impl CageConfig {
+impl EnclaveConfig {
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -408,41 +408,41 @@ impl CageConfig {
         self.scaling = Some(scaling_info);
     }
 
-    pub fn try_from_filepath(path: &str) -> Result<Self, CageConfigError> {
+    pub fn try_from_filepath(path: &str) -> Result<Self, EnclaveConfigError> {
         let config_path = std::path::Path::new(path);
         if !config_path.exists() {
-            return Err(CageConfigError::MissingConfigFile(path.to_string()));
+            return Err(EnclaveConfigError::MissingConfigFile(path.to_string()));
         }
 
-        let cage_config_content = std::fs::read(config_path)?;
-        Ok(toml::de::from_slice(cage_config_content.as_slice())?)
+        let enclave_config_content = std::fs::read(config_path)?;
+        Ok(toml::de::from_slice(enclave_config_content.as_slice())?)
     }
 
-    pub fn get_cage_domain(&self) -> Result<String, CageConfigError> {
+    pub fn get_enclave_domain(&self) -> Result<String, EnclaveConfigError> {
         if self.uuid.is_none() {
-            return Err(CageConfigError::MissingField("cage_uuid".to_string()));
+            return Err(EnclaveConfigError::MissingField("enclave_uuid".to_string()));
         }
         Ok(format!(
-            "{}.{}.cage.evervault.com",
+            "{}.{}.enclave.evervault.com",
             self.name(),
             self.app_uuid
                 .as_ref()
                 .map(|uuid| uuid.replace('_', "-"))
-                .ok_or_else(|| CageConfigError::MissingField("app_uuid".to_string()))?
+                .ok_or_else(|| EnclaveConfigError::MissingField("app_uuid".to_string()))?
         ))
     }
 
-    pub fn get_attestation(&self) -> Result<&EIFMeasurements, CageConfigError> {
+    pub fn get_attestation(&self) -> Result<&EIFMeasurements, EnclaveConfigError> {
         self.attestation
             .as_ref()
-            .ok_or_else(|| CageConfigError::MissingField("attestation".to_string()))
+            .ok_or_else(|| EnclaveConfigError::MissingField("attestation".to_string()))
     }
 }
 
-impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
-    type Error = CageConfigError;
+impl std::convert::TryFrom<&EnclaveConfig> for ValidatedEnclaveBuildConfig {
+    type Error = EnclaveConfigError;
 
-    fn try_from(config: &CageConfig) -> Result<Self, Self::Error> {
+    fn try_from(config: &EnclaveConfig) -> Result<Self, Self::Error> {
         let signing_info = config
             .signing
             .as_ref()
@@ -451,29 +451,29 @@ impl std::convert::TryFrom<&CageConfig> for ValidatedCageBuildConfig {
         let app_uuid = config
             .app_uuid
             .clone()
-            .ok_or_else(|| CageConfigError::MissingField("App uuid".into()))?;
-        let cage_uuid = config
+            .ok_or_else(|| EnclaveConfigError::MissingField("App uuid".into()))?;
+        let enclave_uuid = config
             .uuid
             .clone()
-            .ok_or_else(|| CageConfigError::MissingField("Cage uuid".into()))?;
+            .ok_or_else(|| EnclaveConfigError::MissingField("Enclave uuid".into()))?;
         let team_uuid = config
             .team_uuid
             .clone()
-            .ok_or_else(|| CageConfigError::MissingField("Team uuid".into()))?;
+            .ok_or_else(|| EnclaveConfigError::MissingField("Team uuid".into()))?;
 
         let trx_logging_enabled = match (config.trx_logging, !config.disable_tls_termination) {
             (false, _) => Ok(false), // (logging disabled, _) = logging disabled
-            (true, false) => Err(CageConfigError::LoggingEnabledWithoutTLSTermination()), // (logging enabled, tls_termination disabled) = config error (Tls termination needed for logging)
+            (true, false) => Err(EnclaveConfigError::LoggingEnabledWithoutTLSTermination()), // (logging enabled, tls_termination disabled) = config error (Tls termination needed for logging)
             (true, true) => Ok(true), // (logging enabled, tls_termination enabled) = logging enabled
         }?;
 
         let scaling_settings = config.scaling.clone();
 
-        Ok(ValidatedCageBuildConfig {
-            cage_uuid,
+        Ok(ValidatedEnclaveBuildConfig {
+            enclave_uuid,
             app_uuid,
             team_uuid,
-            cage_name: config.name.clone(),
+            enclave_name: config.name.clone(),
             debug: config.debug,
             dockerfile: config.dockerfile.clone(),
             egress: config.egress.clone(),
@@ -504,7 +504,7 @@ pub trait BuildTimeConfig {
     }
 
     // Return new copy of config to prevent args being written to toml file in err
-    fn merge_with_config(&self, config: &CageConfig) -> CageConfig {
+    fn merge_with_config(&self, config: &EnclaveConfig) -> EnclaveConfig {
         let mut merged_config = config.clone();
 
         if let Some(cert) = self.certificate() {
@@ -529,17 +529,17 @@ impl BuildTimeConfig for () {}
 pub fn read_and_validate_config<B: BuildTimeConfig>(
     config_path: &str,
     args: &B,
-) -> Result<(CageConfig, ValidatedCageBuildConfig), CageConfigError> {
-    let cage_config = CageConfig::try_from_filepath(config_path)?;
-    let merged_config = args.merge_with_config(&cage_config);
-    let validated_config: ValidatedCageBuildConfig = merged_config.as_ref().try_into()?;
+) -> Result<(EnclaveConfig, ValidatedEnclaveBuildConfig), EnclaveConfigError> {
+    let enclave_config = EnclaveConfig::try_from_filepath(config_path)?;
+    let merged_config = args.merge_with_config(&enclave_config);
+    let validated_config: ValidatedEnclaveBuildConfig = merged_config.as_ref().try_into()?;
 
-    Ok((cage_config, validated_config))
+    Ok((enclave_config, validated_config))
 }
 
 #[cfg(test)]
 mod test {
-    use super::{BuildTimeConfig, CageConfig};
+    use super::{BuildTimeConfig, EnclaveConfig};
 
     struct ExampleArgs {
         cert: String,
@@ -563,8 +563,8 @@ mod test {
 
     #[test]
     fn merge_args_with_config() {
-        let config = CageConfig {
-            name: "Cage123".to_string(),
+        let config = EnclaveConfig {
+            name: "Enclave123".to_string(),
             uuid: Some("abcdef123".to_string()),
             app_uuid: Some("abcdef321".to_string()),
             team_uuid: Some("team_abcdef456".to_string()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,7 +201,7 @@ pub enum EnclaveConfigError {
     MissingDockerfile,
     #[error("{0} was not set in the toml.")]
     MissingField(String),
-    #[error("TLS Termination must be enabled to enable enclave logging.")]
+    #[error("TLS Termination must be enabled to enable Enclave logging.")]
     LoggingEnabledWithoutTLSTermination(),
 }
 

--- a/src/delete/error.rs
+++ b/src/delete/error.rs
@@ -3,9 +3,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum DeleteError {
-    #[error("An error occurred while reading the cage config — {0}")]
-    CageConfigError(#[from] crate::config::CageConfigError),
-    #[error("No Cage Uuid given. You can provide one by using either the --cage-uuid flag, or using the --config flag to point to a Cage.toml")]
+    #[error("An error occurred while reading the enclave config — {0}")]
+    EnclaveConfigError(#[from] crate::config::EnclaveConfigError),
+    #[error("No Enclave Uuid given. You can provide one by using either the --enclave-uuid flag, or using the --config flag to point to an Enclave.toml")]
     MissingUuid,
     #[error("An IO error occurred {0}")]
     IoError(#[from] std::io::Error),
@@ -16,7 +16,7 @@ pub enum DeleteError {
 impl CliError for DeleteError {
     fn exitcode(&self) -> exitcode::ExitCode {
         match self {
-            Self::CageConfigError(config_err) => config_err.exitcode(),
+            Self::EnclaveConfigError(config_err) => config_err.exitcode(),
             Self::IoError(_) => exitcode::IOERR,
             Self::ApiError(api_err) => api_err.exitcode(),
             Self::MissingUuid => exitcode::DATAERR,

--- a/src/delete/error.rs
+++ b/src/delete/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum DeleteError {
-    #[error("An error occurred while reading the enclave config — {0}")]
+    #[error("An error occurred while reading the Enclave config — {0}")]
     EnclaveConfigError(#[from] crate::config::EnclaveConfigError),
     #[error("No Enclave Uuid given. You can provide one by using either the --enclave-uuid flag, or using the --config flag to point to an Enclave.toml")]
     MissingUuid,

--- a/src/deploy/error.rs
+++ b/src/deploy/error.rs
@@ -8,7 +8,7 @@ pub enum DeployError {
     DescribeError(#[from] crate::describe::error::DescribeError),
     #[error("Could not build eif {0}")]
     BuildError(#[from] crate::build::error::BuildError),
-    #[error("An error occurred while reading the enclave config — {0}")]
+    #[error("An error occurred while reading the Enclave config — {0}")]
     EnclaveConfigError(#[from] crate::config::EnclaveConfigError),
     #[error("Failed to access output directory — {0}")]
     FailedToAccessOutputDir(#[from] OutputPathError),
@@ -24,7 +24,7 @@ pub enum DeployError {
     UploadError(String),
     #[error("Could not read the size of the Enclave EIF file {0}")]
     EifSizeReadError(std::io::Error),
-    #[error("Could not deploy enclave to Evervault Infrastructure")]
+    #[error("Could not deploy Enclave to Evervault Infrastructure")]
     DeploymentError,
     #[error("[{0}] Operation timed out after {1} seconds")]
     TimeoutError(String, u64),

--- a/src/deploy/error.rs
+++ b/src/deploy/error.rs
@@ -8,8 +8,8 @@ pub enum DeployError {
     DescribeError(#[from] crate::describe::error::DescribeError),
     #[error("Could not build eif {0}")]
     BuildError(#[from] crate::build::error::BuildError),
-    #[error("An error occurred while reading the cage config — {0}")]
-    CageConfigError(#[from] crate::config::CageConfigError),
+    #[error("An error occurred while reading the enclave config — {0}")]
+    EnclaveConfigError(#[from] crate::config::EnclaveConfigError),
     #[error("Failed to access output directory — {0}")]
     FailedToAccessOutputDir(#[from] OutputPathError),
     #[error("An IO error occurred {0}")]
@@ -20,11 +20,11 @@ pub enum DeployError {
     RequestError(#[from] reqwest::Error),
     #[error("An error occured contacting the API — {0}")]
     ApiError(#[from] crate::api::client::ApiError),
-    #[error("Cage failed to upload - {0}")]
+    #[error("Enclave failed to upload - {0}")]
     UploadError(String),
-    #[error("Could not read the size of the Cage EIF file {0}")]
+    #[error("Could not read the size of the Enclave EIF file {0}")]
     EifSizeReadError(std::io::Error),
-    #[error("Could not deploy cage to Evervault Infrastructure")]
+    #[error("Could not deploy enclave to Evervault Infrastructure")]
     DeploymentError,
     #[error("[{0}] Operation timed out after {1} seconds")]
     TimeoutError(String, u64),
@@ -35,7 +35,7 @@ impl CliError for DeployError {
         match self {
             Self::DescribeError(describe_err) => describe_err.exitcode(),
             Self::BuildError(build_err) => build_err.exitcode(),
-            Self::CageConfigError(config_err) => config_err.exitcode(),
+            Self::EnclaveConfigError(config_err) => config_err.exitcode(),
             Self::FailedToAccessOutputDir(output_err) => output_err.exitcode(),
             Self::IoError(_) | Self::ZipError(_) | Self::EifSizeReadError(_) => exitcode::IOERR,
             Self::RequestError(_)

--- a/src/describe/error.rs
+++ b/src/describe/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum DescribeError {
-    #[error("Failed to describe enclave image file — {0}")]
+    #[error("Failed to describe Enclave image file — {0}")]
     DockerError(#[from] DockerError),
     #[error("Could not find eif at {0}")]
     EIFNotFound(std::path::PathBuf),

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -1,7 +1,7 @@
-use crate::config::CageConfigError;
+use crate::config::EnclaveConfigError;
 use crate::{
     api::{
-        cage::{CageApi, CagesClient},
+        enclave::{EnclaveApi, EnclaveClient},
         AuthMode,
     },
     cli::encrypt::CurveName,
@@ -14,7 +14,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum EncryptError {
-    #[error("Team uuid and app uuid must be provided as arg or in cage toml")]
+    #[error("Team uuid and app uuid must be provided as arg or in enclave toml")]
     MissingUuid,
     #[error("An error occurred contacting the API — {0}")]
     ApiError(#[from] crate::api::client::ApiError),
@@ -22,8 +22,8 @@ pub enum EncryptError {
     Base64DecodeError(#[from] base64::DecodeError),
     #[error("An error occurred during decryption — {0}")]
     EvervaultCryptoError(#[from] EvervaultCryptoError),
-    #[error("An error occured reading cage.toml — {0}")]
-    CageConfigError(#[from] CageConfigError),
+    #[error("An error occured reading enclave.toml — {0}")]
+    EnclaveConfigError(#[from] EnclaveConfigError),
 }
 
 pub async fn encrypt(
@@ -32,8 +32,8 @@ pub async fn encrypt(
     app_uuid: String,
     curve: CurveName,
 ) -> Result<String, EncryptError> {
-    let cage_api = CagesClient::new(AuthMode::NoAuth);
-    let keys = cage_api.get_app_keys(&team_uuid, &app_uuid).await?;
+    let enclave_api = EnclaveClient::new(AuthMode::NoAuth);
+    let keys = enclave_api.get_app_keys(&team_uuid, &app_uuid).await?;
 
     let result = match curve {
         CurveName::Nist | CurveName::Secp256r1 => {

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum EncryptError {
-    #[error("Team uuid and app uuid must be provided as arg or in enclave toml")]
+    #[error("Team uuid and app uuid must be provided as arg or in Enclave toml")]
     MissingUuid,
     #[error("An error occurred contacting the API — {0}")]
     ApiError(#[from] crate::api::client::ApiError),

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -1,6 +1,6 @@
-use crate::api::cage::{AddSecretRequest, CageApi, CageEnv, CagesClient};
+use crate::api::enclave::{AddSecretRequest, EnclaveApi, EnclaveClient, EnclaveEnv};
 use crate::cli::env::EnvCommands;
-use crate::config::{CageConfig, CageConfigError};
+use crate::config::{EnclaveConfig, EnclaveConfigError};
 use crate::encrypt::{self, encrypt};
 #[cfg(feature = "internal_dependency")]
 use rust_crypto::EvervaultCryptoError;
@@ -14,18 +14,21 @@ pub enum EnvError {
     Base64DecodeError(#[from] base64::DecodeError),
     #[error("An error occurred during decryption — {0}")]
     EvervaultCryptoError(#[from] EvervaultCryptoError),
-    #[error("App and team uuid need to be provided in cage.toml or as args")]
+    #[error("App and team uuid need to be provided in enclave.toml or as args")]
     MissingAppInfo,
     #[error("An error occured during encryption — {0}")]
     EncryptError(#[from] encrypt::EncryptError),
-    #[error("An error occured reading cage.toml — {0}")]
-    CageConfigError(#[from] CageConfigError),
+    #[error("An error occured reading enclave.toml — {0}")]
+    EnclaveConfigError(#[from] EnclaveConfigError),
 }
 
-pub async fn env(client: CagesClient, action: EnvCommands) -> Result<Option<CageEnv>, EnvError> {
+pub async fn env(
+    client: EnclaveClient,
+    action: EnvCommands,
+) -> Result<Option<EnclaveEnv>, EnvError> {
     match action {
         EnvCommands::Add(command) => {
-            let details = get_cage_details(command.config)?;
+            let details = get_enclave_details(command.config)?;
             let env_secret = if command.is_secret {
                 encrypt(
                     command.secret,
@@ -46,36 +49,36 @@ pub async fn env(client: CagesClient, action: EnvCommands) -> Result<Option<Cage
             Ok(None)
         }
         EnvCommands::Delete(command) => {
-            let details = get_cage_details(command.config)?;
+            let details = get_enclave_details(command.config)?;
             client.delete_env_var(details.uuid, command.name).await?;
             Ok(None)
         }
         EnvCommands::Get(command) => {
-            let details = get_cage_details(command.config)?;
-            Ok(Some(client.get_cage_env(details.uuid).await?))
+            let details = get_enclave_details(command.config)?;
+            Ok(Some(client.get_enclave_env(details.uuid).await?))
         }
     }
 }
 
-pub struct CageInfo {
+pub struct EnclaveInfo {
     pub uuid: String,
     pub team_uuid: String,
     pub app_uuid: String,
 }
 
-fn get_cage_details(config_path: String) -> Result<CageInfo, EnvError> {
-    let cage_config = CageConfig::try_from_filepath(&config_path)?;
+fn get_enclave_details(config_path: String) -> Result<EnclaveInfo, EnvError> {
+    let enclave_config = EnclaveConfig::try_from_filepath(&config_path)?;
 
-    if cage_config.app_uuid.is_none()
-        || cage_config.team_uuid.is_none()
-        || cage_config.uuid.is_none()
+    if enclave_config.app_uuid.is_none()
+        || enclave_config.team_uuid.is_none()
+        || enclave_config.uuid.is_none()
     {
         Err(EnvError::MissingAppInfo)
     } else {
-        Ok(CageInfo {
-            app_uuid: cage_config.app_uuid.unwrap(),
-            team_uuid: cage_config.team_uuid.unwrap(),
-            uuid: cage_config.uuid.unwrap(),
+        Ok(EnclaveInfo {
+            app_uuid: enclave_config.app_uuid.unwrap(),
+            team_uuid: enclave_config.team_uuid.unwrap(),
+            uuid: enclave_config.uuid.unwrap(),
         })
     }
 }

--- a/src/logs/mod.rs
+++ b/src/logs/mod.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 use thiserror::Error;
 
 use crate::{
-    api::cage::{CageApi, CagesClient},
+    api::enclave::{EnclaveApi, EnclaveClient},
     common::CliError,
 };
 
@@ -37,8 +37,8 @@ impl CliError for LogsError {
 pub async fn get_logs(
     start_time: Option<String>,
     end_time: Option<String>,
-    cage_uuid: String,
-    cages_client: CagesClient,
+    enclave_uuid: String,
+    enclave_client: EnclaveClient,
 ) -> Result<(), LogsError> {
     let now = std::time::SystemTime::now();
     let log_end_time = match end_time {
@@ -55,11 +55,11 @@ pub async fn get_logs(
             .as_millis(),
     };
 
-    let cage_logs = cages_client
-        .get_cage_logs(cage_uuid.as_str(), log_start_time, log_end_time)
+    let enclave_logs = enclave_client
+        .get_enclave_logs(enclave_uuid.as_str(), log_start_time, log_end_time)
         .await?;
 
-    if cage_logs.log_events().is_empty() {
+    if enclave_logs.log_events().is_empty() {
         return Err(LogsError::NoLogsFound(format!(
             "No logs found between {log_start_time} and {log_end_time}"
         )));
@@ -69,10 +69,10 @@ pub async fn get_logs(
 
     output.set_prompt(format!(
         "Retrieved {} logs from {log_start_time} to {log_end_time}",
-        cage_logs.log_events().len()
+        enclave_logs.log_events().len()
     ))?;
 
-    cage_logs
+    enclave_logs
         .log_events()
         .iter()
         .filter_map(|event| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,20 +3,20 @@ use clap::{AppSettings, Parser};
 use env_logger::fmt::Formatter;
 use env_logger::{Builder, Env};
 #[cfg(not(target_os = "windows"))]
-use ev_cage::cli::attest;
-use ev_cage::cli::{
+use ev_enclave::cli::attest;
+use ev_enclave::cli::{
     build, cert, delete, deploy, describe, init, list, logs, restart, scale, update, Command,
 };
 
 #[cfg(feature = "internal_dependency")]
-use ev_cage::cli::{dev, encrypt, env};
+use ev_enclave::cli::{dev, encrypt, env};
 use human_panic::setup_panic;
 use log::Record;
 use std::io::Write;
 
 #[derive(Debug, Parser)]
 #[clap(
-    name = "Evervault Cage CLI",
+    name = "Evervault Enclave CLI",
     author = "engineering@evervault.com",
     version,
     setting = AppSettings::ArgRequiredElseHelp,
@@ -103,9 +103,9 @@ fn setup_logger(verbose_logging: bool) {
         .format_module_path(false)
         .format_target(false);
     if verbose_logging {
-        builder.filter(Some("ev-cage"), log::LevelFilter::Debug);
+        builder.filter(Some("ev-enclave"), log::LevelFilter::Debug);
     } else {
-        builder.filter(Some("ev-cage"), log::LevelFilter::Info);
+        builder.filter(Some("ev-enclave"), log::LevelFilter::Info);
     }
     builder.format(log_formatter).init();
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,7 +1,7 @@
 use atty::Stream;
 use indicatif::{ProgressBar, ProgressStyle};
 
-use crate::api::cage::CageApi;
+use crate::api::enclave::EnclaveApi;
 use crate::common::CliError;
 
 const MAX_SUCCESSIVE_POLLING_ERRORS: i32 = 5; // # attempts allowed at 6s intervals
@@ -11,7 +11,7 @@ fn get_progress_bar(start_msg: &str, upload_len: Option<u64>) -> ProgressBar {
         Some(len) => {
             let progress_bar = ProgressBar::new(len);
             progress_bar.set_style(ProgressStyle::default_bar()
-            .template("Uploading Cage to Evervault {bar:40.green/blue} {bytes} ({percent}%) [{elapsed_precise}]")
+            .template("Uploading Enclave to Evervault {bar:40.green/blue} {bytes} ({percent}%) [{elapsed_precise}]")
             .expect("Failed to create progress bar template from hardcoded template")
             .progress_chars("##-"));
             progress_bar
@@ -141,7 +141,7 @@ impl StatusReport {
 }
 
 // It should be possible to resolve the lifetimes to allow this work over borrows for every value instead of cloning/heap allocating
-pub async fn poll_fn_and_report_status<T: CageApi, E, F, Fut>(
+pub async fn poll_fn_and_report_status<T: EnclaveApi, E, F, Fut>(
     api_client: std::sync::Arc<T>,
     poll_args: Vec<String>,
     poll_fn: F,

--- a/src/restart/mod.rs
+++ b/src/restart/mod.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum RestartError {
-    #[error("An error occurred while reading the enclave config — {0}")]
+    #[error("An error occurred while reading the Enclave config — {0}")]
     EnclaveConfigError(#[from] crate::config::EnclaveConfigError),
     #[error("No Enclave Uuid given. You can provide one by using either the --enclave-uuid flag, or using the --config flag to point to an Enclave.toml")]
     MissingUuid,
@@ -39,7 +39,7 @@ pub async fn restart_enclave(
         _ => return Err(RestartError::MissingUuid),
     };
 
-    println!("Restarting enclave {}...", enclave_uuid);
+    println!("Restarting Enclave {}...", enclave_uuid);
 
     Ok(enclave_api.restart_enclave(&enclave_uuid).await?)
 }

--- a/src/restart/mod.rs
+++ b/src/restart/mod.rs
@@ -1,14 +1,14 @@
 use crate::{
-    api::cage::{CageApi, CageDeployment, CagesClient},
+    api::enclave::{EnclaveApi, EnclaveClient, EnclaveDeployment},
     common::CliError,
 };
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum RestartError {
-    #[error("An error occurred while reading the cage config — {0}")]
-    CageConfigError(#[from] crate::config::CageConfigError),
-    #[error("No Cage Uuid given. You can provide one by using either the --cage-uuid flag, or using the --config flag to point to a Cage.toml")]
+    #[error("An error occurred while reading the enclave config — {0}")]
+    EnclaveConfigError(#[from] crate::config::EnclaveConfigError),
+    #[error("No Enclave Uuid given. You can provide one by using either the --enclave-uuid flag, or using the --config flag to point to an Enclave.toml")]
     MissingUuid,
     #[error("An IO error occurred {0}")]
     IoError(#[from] std::io::Error),
@@ -19,7 +19,7 @@ pub enum RestartError {
 impl CliError for RestartError {
     fn exitcode(&self) -> exitcode::ExitCode {
         match self {
-            Self::CageConfigError(config_err) => config_err.exitcode(),
+            Self::EnclaveConfigError(config_err) => config_err.exitcode(),
             Self::IoError(_) => exitcode::IOERR,
             Self::ApiError(api_err) => api_err.exitcode(),
             Self::MissingUuid => exitcode::DATAERR,
@@ -27,19 +27,19 @@ impl CliError for RestartError {
     }
 }
 
-pub async fn restart_cage(
+pub async fn restart_enclave(
     config: &str,
-    cage_uuid: Option<&str>,
-    cage_api: &CagesClient,
+    enclave_uuid: Option<&str>,
+    enclave_api: &EnclaveClient,
     _background: bool,
-) -> Result<CageDeployment, RestartError> {
-    let maybe_cage_uuid = crate::common::resolve_cage_uuid(cage_uuid, config)?;
-    let cage_uuid = match maybe_cage_uuid {
-        Some(given_cage_uuid) => given_cage_uuid,
+) -> Result<EnclaveDeployment, RestartError> {
+    let maybe_enclave_uuid = crate::common::resolve_enclave_uuid(enclave_uuid, config)?;
+    let enclave_uuid = match maybe_enclave_uuid {
+        Some(given_enclave_uuid) => given_enclave_uuid,
         _ => return Err(RestartError::MissingUuid),
     };
 
-    println!("Restarting cage {}...", cage_uuid);
+    println!("Restarting enclave {}...", enclave_uuid);
 
-    Ok(cage_api.restart_cage(&cage_uuid).await?)
+    Ok(enclave_api.restart_enclave(&enclave_uuid).await?)
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,15 +1,16 @@
 use crate::api::assets::AssetsClient;
-use crate::api::cage::{
-    BuildStatus, Cage, CageDeployment, CageRegionalDeployment, CageSigningCert, CageState,
-    CageVersion, DeployStatus, DeploymentsForGetCage, GetCageDeploymentResponse, GetCageResponse,
+use crate::api::enclave::{
+    BuildStatus, DeployStatus, DeploymentsForGetEnclave, Enclave, EnclaveDeployment,
+    EnclaveRegionalDeployment, EnclaveSigningCert, EnclaveState, EnclaveVersion,
+    GetEnclaveDeploymentResponse, GetEnclaveResponse,
 };
 use crate::build::build_enclave_image_file;
 use crate::build::error::BuildError;
 use crate::common::OutputPath;
-use crate::config::{read_and_validate_config, ValidatedCageBuildConfig};
+use crate::config::{read_and_validate_config, ValidatedEnclaveBuildConfig};
 use crate::enclave::BuiltEnclave;
 
-pub async fn build_test_cage(
+pub async fn build_test_enclave(
     output_dir: Option<&str>,
     from_existing: Option<String>,
     reproducible: bool,
@@ -39,23 +40,23 @@ pub async fn build_test_cage(
     .await
 }
 
-fn get_test_build_args() -> ValidatedCageBuildConfig {
-    let (_cage_config, validated_config) = read_and_validate_config("./test.cage.toml", &())
+fn get_test_build_args() -> ValidatedEnclaveBuildConfig {
+    let (_enclave_config, validated_config) = read_and_validate_config("./test.enclave.toml", &())
         .expect("Testing config failed to validate");
     validated_config
 }
 
-pub fn build_get_cage_response(
-    state: CageState,
-    deployments: Vec<DeploymentsForGetCage>,
-) -> GetCageResponse {
-    GetCageResponse {
-        cage: Cage {
+pub fn build_get_enclave_response(
+    state: EnclaveState,
+    deployments: Vec<DeploymentsForGetEnclave>,
+) -> GetEnclaveResponse {
+    GetEnclaveResponse {
+        enclaves: Enclave {
             uuid: "abc".into(),
             name: "def".into(),
             team_uuid: "team_123".into(),
             app_uuid: "app_456".into(),
-            domain: "cage.com".into(),
+            domain: "enclave.com".into(),
             state,
             created_at: "".into(),
             updated_at: "".into(),
@@ -64,23 +65,23 @@ pub fn build_get_cage_response(
     }
 }
 
-pub fn build_get_cage_deployment(
+pub fn build_get_enclave_deployment(
     build_status: BuildStatus,
     deploy_status: DeployStatus,
     started_at: Option<String>,
     completed_at: Option<String>,
-) -> GetCageDeploymentResponse {
-    GetCageDeploymentResponse {
-        deployment: CageDeployment {
+) -> GetEnclaveDeploymentResponse {
+    GetEnclaveDeploymentResponse {
+        deployment: EnclaveDeployment {
             uuid: "".into(),
-            cage_uuid: "".into(),
+            enclave_uuid: "".into(),
             version_uuid: "".into(),
             signing_cert_uuid: "".into(),
             debug_mode: true,
             started_at: started_at.clone(),
             completed_at: completed_at.clone(),
         },
-        tee_cage_version: CageVersion {
+        tee_enclave_version: EnclaveVersion {
             uuid: "".into(),
             version: 0,
             control_plane_img_url: Some("".into()),
@@ -91,7 +92,7 @@ pub fn build_get_cage_deployment(
             started_at: started_at.clone(),
             healthcheck: None,
         },
-        tee_cage_signing_cert: CageSigningCert {
+        tee_enclave_signing_cert: EnclaveSigningCert {
             name: Some("".into()),
             uuid: "".into(),
             app_uuid: "".into(),
@@ -99,7 +100,7 @@ pub fn build_get_cage_deployment(
             not_before: None,
             not_after: None,
         },
-        tee_cage_regional_deployments: vec![CageRegionalDeployment {
+        tee_enclave_regional_deployments: vec![EnclaveRegionalDeployment {
             uuid: "".into(),
             deployment_uuid: "".into(),
             deployment_order: 0,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -81,7 +81,7 @@ pub fn build_get_enclave_deployment(
             started_at: started_at.clone(),
             completed_at: completed_at.clone(),
         },
-        tee_enclave_version: EnclaveVersion {
+        enclave_version: EnclaveVersion {
             uuid: "".into(),
             version: 0,
             control_plane_img_url: Some("".into()),
@@ -92,7 +92,7 @@ pub fn build_get_enclave_deployment(
             started_at: started_at.clone(),
             healthcheck: None,
         },
-        tee_enclave_signing_cert: EnclaveSigningCert {
+        enclave_signing_cert: EnclaveSigningCert {
             name: Some("".into()),
             uuid: "".into(),
             app_uuid: "".into(),
@@ -100,7 +100,7 @@ pub fn build_get_enclave_deployment(
             not_before: None,
             not_after: None,
         },
-        tee_enclave_regional_deployments: vec![EnclaveRegionalDeployment {
+        enclave_regional_deployments: vec![EnclaveRegionalDeployment {
             uuid: "".into(),
             deployment_uuid: "".into(),
             deployment_order: 0,

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -13,7 +13,7 @@ pub enum VersionError {
     SemVerError(#[from] semver::Error),
     #[error("Couldn't parse env string as int - {0}")]
     ParseIntError(#[from] std::num::ParseIntError),
-    #[error("This version is deprecated, please run ev-cage update to continue")]
+    #[error("This version is deprecated, please run ev-enclave update to continue")]
     DeprecatedVersion,
     #[error("Couldn't check version against latest")]
     FailedVersionCheck,

--- a/test.enclave.toml
+++ b/test.enclave.toml
@@ -1,4 +1,4 @@
-name = "test-cage"
+name = "test-enclave"
 uuid = "1234"
 app_uuid = "4321"
 team_uuid = "teamid"
@@ -19,7 +19,7 @@ keyPath = "./key.pem"
 
 [attestation]
 HashAlgorithm = "Sha384 { ... }"
-PCR0 = "4d99ce0096bffeea435c41016e9d64aa51caae95d7846fb7c8708f590d31be1fc704adc13bedabbcb2980d6612dde6e9"
+PCR0 = "1cd2135a6358458e390904fac3568eff4e6c7882c22e7925a830c8ba6b9b1ae117dd714cad64b1001475923a242fc887"
 PCR1 = "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f"
 PCR2 = "42997b22af1f96a6b32372402af03a5d16e47316e7990314bdb01c0759fa11a7ae88e3ae2f3628b1c1ab734ea2f2ba34"
 PCR8 = "a94237284c822603176cfe5abbf62664a786b8eef7c5ead7ff725fc2750f06520ce775fec55405ac1837cf2c42e1443a"

--- a/testRepro.Dockerfile
+++ b/testRepro.Dockerfile
@@ -2,12 +2,12 @@ FROM alpine@sha256:c0d488a800e4127c334ad20d61d7bc21b4097540327217dfab52262adc023
 RUN touch /hello-script;\
     /bin/sh -c "echo -e '"'#!/bin/sh\nwhile true; do echo "hello"; sleep 2; done;\n'"' > /hello-script"
 RUN mkdir -p /opt/evervault
-ADD https://cage-build-assets.evervault.com/installer/b8073166b7c5bc8fe2abf192f66e1106f2d4be547b1841be69f95ff2c4ea578c.tar.gz /opt/evervault/runtime-dependencies.tar.gz
+ADD https://enclave-build-assets.evervault.com/installer/b8073166b7c5bc8fe2abf192f66e1106f2d4be547b1841be69f95ff2c4ea578c.tar.gz /opt/evervault/runtime-dependencies.tar.gz
 RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
 RUN echo {\"api_key_auth\":true,\"trx_logging_enabled\":true} > /etc/dataplane-config.json
 RUN mkdir -p /etc/service/user-entrypoint
-RUN printf "#!/bin/sh\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_CAGE_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
-ADD https://cage-build-assets.evervault.com/runtime/0.0.31/data-plane/egress-disabled/tls-termination-enabled /opt/evervault/data-plane
+RUN printf "#!/bin/sh\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
+ADD https://enclave-build-assets.evervault.com/runtime/0.0.31/data-plane/egress-disabled/tls-termination-enabled /opt/evervault/data-plane
 RUN chmod +x /opt/evervault/data-plane
 RUN mkdir -p /etc/service/data-plane
 RUN printf "#!/bin/sh\necho \"Booting Evervault data plane...\"\nexec /opt/evervault/data-plane 80\n" > /etc/service/data-plane/run && chmod +x /etc/service/data-plane/run


### PR DESCRIPTION
# Why
We are rebranding Cages

# How
- Rename Cages -> Enclaves
- Use new public API routes 
- CLI name from ev-cage -> ev-enclave

The only thing not updated are docs links and the synthetic cage domain that will be updated at a later stage
