### PR TITLE
Push to cage build assets bucket

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -217,26 +217,26 @@ jobs:
 
       - name: Upload Windows CLI to S3
         run: |
-          aws s3 cp ./windows/ev-enclave-${{ env.WINDOWS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://enclave-build-assets-${{ inputs.stage }}/cli/${{ inputs.full-version }}/${{ inputs.full-version}}/${{ env.WINDOWS_TARGET }}/ev-enclave.tar.gz
+          aws s3 cp ./windows/ev-enclave-${{ env.WINDOWS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.full-version }}/${{ inputs.full-version}}/${{ env.WINDOWS_TARGET }}/ev-enclave.tar.gz
 
       - name: Upload MacOS CLI to S3
         run: |
-          aws s3 cp ./macos/ev-enclave-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://enclave-build-assets-${{ inputs.stage }}/cli/${{ inputs.full-version }}/${{ inputs.full-version }}/${{ env.MACOS_TARGET }}/ev-enclave.tar.gz
+          aws s3 cp ./macos/ev-enclave-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.full-version }}/${{ inputs.full-version }}/${{ env.MACOS_TARGET }}/ev-enclave.tar.gz
 
       - name: Upload Ubuntu CLI to S3
         run: |
-          aws s3 cp ./linux/ev-enclave-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz s3://enclave-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/${{ env.LINUX_TARGET }}/ev-enclave.tar.gz
+          aws s3 cp ./linux/ev-enclave-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/${{ env.LINUX_TARGET }}/ev-enclave.tar.gz
 
       - uses: actions/checkout@v3
       - name: Update install script in S3
         run: |
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }}
           sh ./scripts/update-versions.sh ${{ inputs.full-version }}
-          aws s3 cp scripts/install s3://enclave-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install
-          aws s3 cp scripts/install s3://enclave-build-assets-${{ inputs.stage }}/cli/install
-          aws s3 cp scripts/version s3://enclave-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/version
-          aws s3 cp scripts/version s3://enclave-build-assets-${{ inputs.stage }}/cli/version
-          aws s3 cp scripts/versions s3://enclave-build-assets-${{ inputs.stage }}/cli/versions
+          aws s3 cp scripts/install s3://cage -build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install
+          aws s3 cp scripts/install s3://cage -build-assets-${{ inputs.stage }}/cli/install
+          aws s3 cp scripts/version s3://cage -build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/version
+          aws s3 cp scripts/version s3://cage -build-assets-${{ inputs.stage }}/cli/version
+          aws s3 cp scripts/versions s3://cage -build-assets-${{ inputs.stage }}/cli/versions
           aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/cli/install" "/cli/version" "/cli/versions"
 
 


### PR DESCRIPTION
# Why
Theres a CF alias to enclave-build-assets but the bucket is still called cage-build-assets

# How
Revert name change
