### PR TITLE
Checkout repo in get version step

### DIFF
--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -40,6 +40,7 @@ jobs:
     outputs:
       full_version: ${{ steps.get-full-version.outputs.full_version }}
     steps:
+      - uses: actions/checkout@v2
       - id: get-full-version
         run: |
           echo "using sha tag ${GITHUB_SHA::6}"

--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -7,7 +7,7 @@ jobs:
   clippy_check_cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-hub/docker/cli@f5fdbfc3f9d2a9265ead8962c1314108a7b7ec5d
         env:
           SKIP_LOGIN: true
@@ -40,7 +40,7 @@ jobs:
     outputs:
       full_version: ${{ steps.get-full-version.outputs.full_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: get-full-version
         run: |
           echo "using sha tag ${GITHUB_SHA::6}"

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -23,7 +23,7 @@ jobs:
       full_version: ${{ steps.get-full-version.outputs.full_version }}
       major_version: ${{ steps.get-major-version.outputs.result }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: get-full-version
         run: |
           echo "using version tag ${GITHUB_REF:11}"

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -23,6 +23,7 @@ jobs:
       full_version: ${{ steps.get-full-version.outputs.full_version }}
       major_version: ${{ steps.get-major-version.outputs.result }}
     steps:
+      - uses: actions/checkout@v2
       - id: get-full-version
         run: |
           echo "using version tag ${GITHUB_REF:11}"


### PR DESCRIPTION
# Why
Getting this on staging release
```
Run MAJOR=$(cargo metadata --no-deps | jq -r '.packages[] | select(.name == "ev-cage") | .version[0:1]')
error: could not find `Cargo.toml` in `/home/runner/work/cage-cli/cage-cli` or any parent directory
```
https://github.com/evervault/cage-cli/actions/runs/7196929880/job/19681701005

# How
Checkout the repo in the get version job
