### PR TITLE
Add cargo sparse registry

### DIFF
--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -44,6 +44,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: get-major
+        env:
+          MAJOR: ${{ steps.get-major.outputs.major-version }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
+          CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
         run: |
           MAJOR=$(cargo metadata --no-deps | jq -r '.packages[] | select(.name == "ev-cage") | .version[0:1]')
           echo "major-version=$MAJOR" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Why
Cargo failing as it doesn't have the sparse index for our rust libraries crate

```
Run MAJOR=$(cargo metadata --no-deps | jq -r '.packages[] | select(.name == "ev-cage") | .version[0:1]')
error: failed to parse manifest at `/home/runner/work/cage-cli/cage-cli/Cargo.toml`

Caused by:
  registry index was not found in any configuration: `evervault-rust-libraries`
```

# How
Add enc vars
