### PR TITLE
Remove snake case flags in Cages cli

### DIFF
--- a/src/cli/encrypt.rs
+++ b/src/cli/encrypt.rs
@@ -24,10 +24,10 @@ pub struct EncryptArgs {
     #[clap(arg_enum, default_value = "nist", long = "curve")]
     pub curve: CurveName,
 
-    #[clap(long = "team_uuid")]
+    #[clap(long = "team-uuid")]
     pub team_uuid: Option<String>,
 
-    #[clap(long = "app_uuid")]
+    #[clap(long = "app-uuid")]
     pub app_uuid: Option<String>,
 
     /// Path to enclave.toml config file

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -79,7 +79,7 @@ pub struct InitArgs {
     pub forward_proxy_protocol: bool,
 
     /// Trusted headers sent into the Enclave will be persisted without redaction in the Enclave's transaction logs
-    #[clap(long = "trusted_headers")]
+    #[clap(long = "trusted-headers")]
     pub trusted_headers: Option<String>,
 
     /// The healthcheck endpoint exposed by your service
@@ -87,7 +87,7 @@ pub struct InitArgs {
     pub healthcheck: Option<String>,
 
     /// The desired number of instances for your Enclave to use. Default is 2.
-    #[clap(long = "desired_replicas")]
+    #[clap(long = "desired-replicas")]
     pub desired_replicas: Option<u32>,
 }
 


### PR DESCRIPTION
# Why
Inconsistent casing in the CLI

# How
Move everything to be hyphenated
