### PR TITLE
Update cli to release only under major version for release/v* branches

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -220,11 +220,11 @@ jobs:
 
       - name: Upload Windows CLI to S3
         run: |
-          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.full-version }}/${{ inputs.full-version}}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./windows/ev-cage-${{ env.WINDOWS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version}}/${{ env.WINDOWS_TARGET }}/ev-cage.tar.gz
 
       - name: Upload MacOS CLI to S3
         run: |
-          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.full-version }}/${{ inputs.full-version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
+          aws s3 cp ./macos/ev-cage-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/${{ env.MACOS_TARGET }}/ev-cage.tar.gz
 
       - name: Upload Ubuntu CLI to S3
         run: |

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,7 +14,10 @@ on:
         type: string 
       ev-domain:
         required: true
-        type: string   
+        type: string 
+      base-branch:
+        required: false
+        type: string
     secrets:    
       aws-cloudfront-distribution-id:
         required: true
@@ -228,15 +231,23 @@ jobs:
           aws s3 cp ./linux/ev-cage-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/${{ env.LINUX_TARGET }}/ev-cage.tar.gz
 
       - uses: actions/checkout@v3
-      - name: Update install script in S3
+      - name: Update current major install script in S3
         run: |
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }}
           sh ./scripts/update-versions.sh ${{ inputs.full-version }}
           aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install
-          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/install
           aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/version
-          aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/version
           aws s3 cp scripts/versions s3://cage-build-assets-${{ inputs.stage }}/cli/versions
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/cli/install" "/cli/version" "/cli/versions"
-
-
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/cli/versions" "/cli/${{ inputs.major-version }}/version" "/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install"
+      
+      - name: Update latest install script in S3
+        if: ${{ !startsWith(inputs.base-branch, 'refs/heads/release/v') }}
+        run: |
+          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/install
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/cli/install"
+      
+      - name: Support version script for v0
+        if: ${{ startsWith(inputs.base-branch, 'refs/heads/release/v0') }}
+        run: |
+          aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/version
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/cli/version"

--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -67,6 +67,7 @@ jobs:
       major-version: "${{ needs.get-version.outputs.major-version }}" 
       full-version: "${{ needs.get-version.outputs.full-version }}"
       ev-domain: 'evervault.io'
+      base-breanch: ${{ github.ref }}
     secrets:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}

--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -47,6 +47,7 @@ jobs:
       major-version:  ${{ needs.get-version.outputs.major_version }}
       full-version: ${{ needs.get-version.outputs.full_version }}
       ev-domain: 'evervault.com'
+      base-branch: ${{ github.ref }}
     secrets:
       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
# Why
Preview releases currently always upload to the latest path regardless of the major version. This is causing issues with previews across major versions.

# How
Update workflow to only release under the major version for `release/v*` branches