### PR TITLE
Fix typo in publish action call

### DIFF
--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -67,7 +67,7 @@ jobs:
       major-version: "${{ needs.get-version.outputs.major-version }}" 
       full-version: "${{ needs.get-version.outputs.full-version }}"
       ev-domain: 'evervault.io'
-      base-breanch: ${{ github.ref }}
+      base-branch: ${{ github.ref }}
     secrets:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}


### PR DESCRIPTION
# Why
Incorrect parameter name being passed to publish workflow

# How
Rename parameter to `base-branch` from `base-breanch`