### PR TITLE
Add major specific install script

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -236,6 +236,7 @@ jobs:
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }}
           sh ./scripts/update-versions.sh ${{ inputs.full-version }}
           aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install
+          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/install
           aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/version
           aws s3 cp scripts/versions s3://cage-build-assets-${{ inputs.stage }}/cli/versions
           aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/cli/versions" "/cli/${{ inputs.major-version }}/version" "/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install"


### PR DESCRIPTION
# Why
Install script for the releases of old majors are nested under full semantic versions which is awkward to pull from programmatically.

# How
Add an install script under the current major version