### PR TITLE
Support staging attestation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -422,13 +422,23 @@ impl EnclaveConfig {
         if self.uuid.is_none() {
             return Err(EnclaveConfigError::MissingField("enclave_uuid".to_string()));
         }
+        let base_domain = if std::env::var("EV_DOMAIN")
+            .unwrap_or_else(|_| String::from("evervault.com"))
+            == "evervault.io"
+        {
+            "evervault.dev"
+        } else {
+            "evervault.com"
+        };
+
         Ok(format!(
-            "{}.{}.enclave.evervault.com",
+            "{}.{}.enclave.{}",
             self.name(),
             self.app_uuid
                 .as_ref()
                 .map(|uuid| uuid.replace('_', "-"))
-                .ok_or_else(|| EnclaveConfigError::MissingField("app_uuid".to_string()))?
+                .ok_or_else(|| EnclaveConfigError::MissingField("app_uuid".to_string()))?,
+            base_domain
         ))
     }
 

--- a/src/logs/mod.rs
+++ b/src/logs/mod.rs
@@ -19,8 +19,6 @@ pub enum LogsError {
     ParseIntError(#[from] std::num::ParseIntError),
     #[error("Failed to parse timestamps")]
     TimestampFormatError,
-    #[error("{0}")]
-    NoLogsFound(String),
     #[error("An error occurred while paginating your log data - {0}")]
     MinusError(#[from] minus::MinusError),
 }
@@ -60,9 +58,8 @@ pub async fn get_logs(
         .await?;
 
     if enclave_logs.log_events().is_empty() {
-        return Err(LogsError::NoLogsFound(format!(
-            "No logs found between {log_start_time} and {log_end_time}"
-        )));
+        log::info!("No logs found between {log_start_time} and {log_end_time}");
+        return Ok(());
     }
 
     let mut output = minus::Pager::new();


### PR DESCRIPTION
# Why
Cant easily attest staging enclaves atm

# How
- when the staging domain it set then use evervault.dev for attest - I think it would make sense to refactor to use envs but the fix will work for now
- Small DX thing: an error was thrown if there are no logs for a time period, changed to be an info log

<img width="712" alt="Screenshot 2023-12-20 at 14 05 23" src="https://github.com/evervault/cage-cli/assets/92307259/b9cb54cc-badc-49d9-8675-72d06777d9e9">
