### PR TITLE
Add support for no-cache flag when containers are used

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -31,6 +31,7 @@ pub async fn build_enclave_image_file(
     timestamp: String,
     from_existing: Option<String>,
     reproducible: bool,
+    no_cache: bool,
 ) -> Result<(enclave::BuiltEnclave, OutputPath), BuildError> {
     let context_path = Path::new(&context_path);
     if !context_path.exists() {
@@ -56,6 +57,7 @@ pub async fn build_enclave_image_file(
                 verbose,
                 docker_build_args,
                 timestamp,
+                no_cache
             )?;
         }
         None => {
@@ -69,6 +71,7 @@ pub async fn build_enclave_image_file(
                 output_path.path(),
                 timestamp,
                 reproducible,
+                no_cache
             )
             .await?;
         }
@@ -78,7 +81,7 @@ pub async fn build_enclave_image_file(
         log::debug!("Building Nitro CLI image... {output_path}");
     }
 
-    enclave::build_nitro_cli_image(output_path.path(), Some(&signing_info), verbose)?;
+    enclave::build_nitro_cli_image(output_path.path(), Some(&signing_info), verbose, no_cache)?;
     log::info!("Converting docker image to EIF...");
     enclave::run_conversion_to_enclave(output_path.path(), verbose)
         .map(|built_enc| (built_enc, output_path))
@@ -96,6 +99,7 @@ pub async fn build_from_scratch(
     output_path: &Path,
     timestamp: String,
     reproducible: bool,
+    no_cache: bool
 ) -> Result<(), BuildError> {
     if !verify_docker_is_running()? {
         return Err(DockerError::DaemonNotRunning.into());
@@ -145,6 +149,7 @@ pub async fn build_from_scratch(
         verbose,
         docker_build_args,
         timestamp,
+        no_cache
     )?;
     log::debug!("User image built...");
     Ok(())

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -57,7 +57,7 @@ pub async fn build_enclave_image_file(
                 verbose,
                 docker_build_args,
                 timestamp,
-                no_cache
+                no_cache,
             )?;
         }
         None => {
@@ -71,7 +71,7 @@ pub async fn build_enclave_image_file(
                 output_path.path(),
                 timestamp,
                 reproducible,
-                no_cache
+                no_cache,
             )
             .await?;
         }
@@ -99,7 +99,7 @@ pub async fn build_from_scratch(
     output_path: &Path,
     timestamp: String,
     reproducible: bool,
-    no_cache: bool
+    no_cache: bool,
 ) -> Result<(), BuildError> {
     if !verify_docker_is_running()? {
         return Err(DockerError::DaemonNotRunning.into());
@@ -149,7 +149,7 @@ pub async fn build_from_scratch(
         verbose,
         docker_build_args,
         timestamp,
-        no_cache
+        no_cache,
     )?;
     log::debug!("User image built...");
     Ok(())

--- a/src/cli/attest.rs
+++ b/src/cli/attest.rs
@@ -40,7 +40,7 @@ pub async fn run(attest_args: AttestArgs) -> i32 {
     let domain = unwrap_or_exit_with_error!(config.get_enclave_domain());
 
     let expected_pcrs = if let Some(eif_path) = attest_args.eif_path {
-        let description = unwrap_or_exit_with_error!(describe_eif(&eif_path, false));
+        let description = unwrap_or_exit_with_error!(describe_eif(&eif_path, false, false));
         description.measurements.measurements().clone()
     } else {
         unwrap_or_exit_with_error!(config.get_attestation()).clone()

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -130,7 +130,7 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         timestamp,
         from_existing,
         build_args.reproducible,
-        build_args.no_cache
+        build_args.no_cache,
     )
     .await
     {

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -57,6 +57,10 @@ pub struct BuildArgs {
     /// Enables forwarding proxy protocol when TLS Termination is disabled
     #[clap(long = "forward-proxy-protocol")]
     pub forward_proxy_protocol: bool,
+
+    /// Disables the use of cache during the image builds
+    #[clap(long = "no-cache")]
+    pub no_cache: bool,
 }
 
 impl BuildTimeConfig for BuildArgs {
@@ -126,6 +130,7 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         timestamp,
         from_existing,
         build_args.reproducible,
+        build_args.no_cache
     )
     .await
     {

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -176,7 +176,7 @@ pub async fn run(deploy_args: DeployArgs) -> exitcode::ExitCode {
         data_plane_version.clone(),
         installer_version.clone(),
         deploy_args.reproducible,
-        deploy_args.no_cache
+        deploy_args.no_cache,
     )
     .await
     {
@@ -239,7 +239,7 @@ async fn resolve_eif(
     data_plane_version: String,
     installer_version: String,
     reproducible: bool,
-    no_cache: bool
+    no_cache: bool,
 ) -> Result<(EIFMeasurements, OutputPath), exitcode::ExitCode> {
     if let Some(path) = eif_path {
         get_eif(path, verbose, no_cache).map_err(|e| {
@@ -258,7 +258,7 @@ async fn resolve_eif(
             timestamp,
             from_existing,
             reproducible,
-            no_cache
+            no_cache,
         )
         .await
         .map_err(|build_err| {

--- a/src/cli/deploy.rs
+++ b/src/cli/deploy.rs
@@ -62,6 +62,10 @@ pub struct DeployArgs {
     /// Healthcheck path exposed by your service
     #[clap(long = "healthcheck")]
     pub healthcheck: Option<String>,
+
+    /// Disables the use of cache during the image builds
+    #[clap(long = "no-cache")]
+    pub no_cache: bool,
 }
 
 impl BuildTimeConfig for DeployArgs {
@@ -172,6 +176,7 @@ pub async fn run(deploy_args: DeployArgs) -> exitcode::ExitCode {
         data_plane_version.clone(),
         installer_version.clone(),
         deploy_args.reproducible,
+        deploy_args.no_cache
     )
     .await
     {
@@ -234,9 +239,10 @@ async fn resolve_eif(
     data_plane_version: String,
     installer_version: String,
     reproducible: bool,
+    no_cache: bool
 ) -> Result<(EIFMeasurements, OutputPath), exitcode::ExitCode> {
     if let Some(path) = eif_path {
-        get_eif(path, verbose).map_err(|e| {
+        get_eif(path, verbose, no_cache).map_err(|e| {
             log::error!("{e}");
             e.exitcode()
         })
@@ -252,6 +258,7 @@ async fn resolve_eif(
             timestamp,
             from_existing,
             reproducible,
+            no_cache
         )
         .await
         .map_err(|build_err| {

--- a/src/cli/describe.rs
+++ b/src/cli/describe.rs
@@ -26,7 +26,11 @@ pub async fn run(describe_args: DescribeArgs) -> exitcode::ExitCode {
         return exitcode::SOFTWARE;
     };
 
-    let description = match describe_eif(&describe_args.eif_path, !describe_args.quiet, describe_args.no_cache) {
+    let description = match describe_eif(
+        &describe_args.eif_path,
+        !describe_args.quiet,
+        describe_args.no_cache,
+    ) {
         Ok(measurements) => measurements,
         Err(e) => {
             log::error!("{e}");

--- a/src/cli/describe.rs
+++ b/src/cli/describe.rs
@@ -14,6 +14,10 @@ pub struct DescribeArgs {
     /// Disable verbose logging
     #[clap(long)]
     pub quiet: bool,
+
+    /// Disables the use of cache during the image builds
+    #[clap(long = "no-cache")]
+    pub no_cache: bool,
 }
 
 pub async fn run(describe_args: DescribeArgs) -> exitcode::ExitCode {
@@ -22,7 +26,7 @@ pub async fn run(describe_args: DescribeArgs) -> exitcode::ExitCode {
         return exitcode::SOFTWARE;
     };
 
-    let description = match describe_eif(&describe_args.eif_path, !describe_args.quiet) {
+    let description = match describe_eif(&describe_args.eif_path, !describe_args.quiet, describe_args.no_cache) {
         Ok(measurements) => measurements,
         Err(e) => {
             log::error!("{e}");

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -251,7 +251,7 @@ fn create_zip_upload_stream(
 pub fn get_eif<S: AsRef<str>>(
     eif_path: S,
     verbose: bool,
-    no_cache: bool
+    no_cache: bool,
 ) -> Result<(EIFMeasurements, OutputPath), DeployError> {
     let eif = describe_eif(eif_path.as_ref(), verbose, no_cache)?;
     let output_path = resolve_output_path(None::<&str>)?;

--- a/src/deploy/mod.rs
+++ b/src/deploy/mod.rs
@@ -251,8 +251,9 @@ fn create_zip_upload_stream(
 pub fn get_eif<S: AsRef<str>>(
     eif_path: S,
     verbose: bool,
+    no_cache: bool
 ) -> Result<(EIFMeasurements, OutputPath), DeployError> {
-    let eif = describe_eif(eif_path.as_ref(), verbose)?;
+    let eif = describe_eif(eif_path.as_ref(), verbose, no_cache)?;
     let output_path = resolve_output_path(None::<&str>)?;
     let output_p = format!("{}/enclave.eif", output_path.path().to_str().unwrap());
     std::fs::copy(eif_path.as_ref(), output_p)?;

--- a/src/describe/mod.rs
+++ b/src/describe/mod.rs
@@ -6,7 +6,11 @@ use crate::enclave;
 use crate::progress::get_tracker;
 use error::DescribeError;
 
-pub fn describe_eif(eif_path: &str, verbose: bool, no_cache: bool) -> Result<enclave::DescribeEif, DescribeError> {
+pub fn describe_eif(
+    eif_path: &str,
+    verbose: bool,
+    no_cache: bool,
+) -> Result<enclave::DescribeEif, DescribeError> {
     let eif_path = std::path::Path::new(eif_path);
     if !eif_path.exists() {
         return Err(DescribeError::EIFNotFound(eif_path.to_path_buf()));

--- a/src/describe/mod.rs
+++ b/src/describe/mod.rs
@@ -6,7 +6,7 @@ use crate::enclave;
 use crate::progress::get_tracker;
 use error::DescribeError;
 
-pub fn describe_eif(eif_path: &str, verbose: bool) -> Result<enclave::DescribeEif, DescribeError> {
+pub fn describe_eif(eif_path: &str, verbose: bool, no_cache: bool) -> Result<enclave::DescribeEif, DescribeError> {
     let eif_path = std::path::Path::new(eif_path);
     if !eif_path.exists() {
         return Err(DescribeError::EIFNotFound(eif_path.to_path_buf()));
@@ -22,7 +22,7 @@ pub fn describe_eif(eif_path: &str, verbose: bool) -> Result<enclave::DescribeEi
 
     let supplied_path: Option<&str> = None;
     let output_path = resolve_output_path(supplied_path).unwrap();
-    enclave::build_nitro_cli_image(output_path.path(), None, verbose)?;
+    enclave::build_nitro_cli_image(output_path.path(), None, verbose, no_cache)?;
 
     let description = enclave::describe_eif(&absolute_path, verbose)?;
     describe_progress.finish_with_message("PCRs retrieved.");

--- a/src/docker/command.rs
+++ b/src/docker/command.rs
@@ -6,15 +6,23 @@ use std::process::{Command, ExitStatus, Output, Stdio};
 
 pub struct CommandConfig {
     verbose: bool,
+    no_cache: bool,
 }
 
 impl CommandConfig {
-    pub fn new(verbose: bool) -> Self {
-        Self { verbose }
+    pub fn new(verbose: bool, no_cache: bool) -> Self {
+        Self { 
+          verbose,
+          no_cache
+        }
     }
 
     pub fn extra_build_args(&self) -> Vec<&OsStr> {
-        vec!["--platform".as_ref(), "linux/amd64".as_ref()]
+        let mut args = vec!["--platform".as_ref(), "linux/amd64".as_ref()];
+        if self.no_cache {
+          args.push("--no-cache".as_ref());
+        }
+        args
     }
 
     pub fn output_setting(&self) -> Stdio {
@@ -30,7 +38,7 @@ pub fn load_image_into_local_docker_registry(
     image_archive: &Path,
     verbose: bool,
 ) -> Result<ExitStatus, CommandError> {
-    let command_config = CommandConfig::new(verbose);
+    let command_config = CommandConfig::new(verbose, false);
     let is_stdout_piped = atty::isnt(atty::Stream::Stdout);
     let docker_load_result = Command::new("docker")
         .args(vec![
@@ -92,8 +100,9 @@ pub fn build_image(
     tag_name: &str,
     command_line_args: Vec<&OsStr>,
     verbose: bool,
+    no_cache: bool
 ) -> Result<ExitStatus, CommandError> {
-    let command_config = CommandConfig::new(verbose);
+    let command_config = CommandConfig::new(verbose, no_cache);
     let build_image_args: Vec<&OsStr> = [
         vec![
             "build".as_ref(),
@@ -122,8 +131,9 @@ pub fn build_image_repro(
     command_line_args: Vec<&OsStr>,
     verbose: bool,
     timestamp: String,
+    no_cache: bool
 ) -> Result<ExitStatus, CommandError> {
-    let command_config = CommandConfig::new(verbose);
+    let command_config = CommandConfig::new(verbose, no_cache);
     let build_image_args = if docker_buildkit_enabled()? {
         log::info!("Docker version is reproducible build compatible");
         [
@@ -172,7 +182,7 @@ pub fn run_image(
     command_line_args: Vec<&OsStr>,
     verbose: bool,
 ) -> Result<Output, CommandError> {
-    let command_config = CommandConfig::new(verbose);
+    let command_config = CommandConfig::new(verbose, false);
 
     let mut run_image_args: Vec<&OsStr> = vec!["run".as_ref(), "--rm".as_ref()];
 

--- a/src/docker/command.rs
+++ b/src/docker/command.rs
@@ -11,16 +11,13 @@ pub struct CommandConfig {
 
 impl CommandConfig {
     pub fn new(verbose: bool, no_cache: bool) -> Self {
-        Self { 
-          verbose,
-          no_cache
-        }
+        Self { verbose, no_cache }
     }
 
     pub fn extra_build_args(&self) -> Vec<&OsStr> {
         let mut args = vec!["--platform".as_ref(), "linux/amd64".as_ref()];
         if self.no_cache {
-          args.push("--no-cache".as_ref());
+            args.push("--no-cache".as_ref());
         }
         args
     }
@@ -100,7 +97,7 @@ pub fn build_image(
     tag_name: &str,
     command_line_args: Vec<&OsStr>,
     verbose: bool,
-    no_cache: bool
+    no_cache: bool,
 ) -> Result<ExitStatus, CommandError> {
     let command_config = CommandConfig::new(verbose, no_cache);
     let build_image_args: Vec<&OsStr> = [
@@ -131,7 +128,7 @@ pub fn build_image_repro(
     command_line_args: Vec<&OsStr>,
     verbose: bool,
     timestamp: String,
-    no_cache: bool
+    no_cache: bool,
 ) -> Result<ExitStatus, CommandError> {
     let command_config = CommandConfig::new(verbose, no_cache);
     let build_image_args = if docker_buildkit_enabled()? {

--- a/src/enclave/mod.rs
+++ b/src/enclave/mod.rs
@@ -25,6 +25,7 @@ pub fn build_user_image(
     verbose: bool,
     docker_build_args: Option<Vec<&str>>,
     timestamp: String,
+    no_cache: bool
 ) -> Result<(), EnclaveError> {
     let mut command_line_args = vec![user_context_path.as_os_str()];
 
@@ -40,6 +41,7 @@ pub fn build_user_image(
         command_line_args,
         verbose,
         timestamp,
+        no_cache
     )?;
 
     if !build_output.success() {
@@ -103,6 +105,7 @@ pub fn build_nitro_cli_image(
     output_dir: &std::path::PathBuf,
     signing_info: Option<&EnclaveSigningInfo>,
     verbose: bool,
+    no_cache: bool
 ) -> Result<(), EnclaveError> {
     let mut nitro_cli_dockerfile_contents = include_bytes!("nitro-cli-image.Dockerfile").to_vec();
 
@@ -134,6 +137,7 @@ pub fn build_nitro_cli_image(
         },
         vec![output_dir.as_ref()],
         verbose,
+        no_cache
     );
 
     let build_image_status =

--- a/src/enclave/mod.rs
+++ b/src/enclave/mod.rs
@@ -25,7 +25,7 @@ pub fn build_user_image(
     verbose: bool,
     docker_build_args: Option<Vec<&str>>,
     timestamp: String,
-    no_cache: bool
+    no_cache: bool,
 ) -> Result<(), EnclaveError> {
     let mut command_line_args = vec![user_context_path.as_os_str()];
 
@@ -41,7 +41,7 @@ pub fn build_user_image(
         command_line_args,
         verbose,
         timestamp,
-        no_cache
+        no_cache,
     )?;
 
     if !build_output.success() {
@@ -105,7 +105,7 @@ pub fn build_nitro_cli_image(
     output_dir: &std::path::PathBuf,
     signing_info: Option<&EnclaveSigningInfo>,
     verbose: bool,
-    no_cache: bool
+    no_cache: bool,
 ) -> Result<(), EnclaveError> {
     let mut nitro_cli_dockerfile_contents = include_bytes!("nitro-cli-image.Dockerfile").to_vec();
 
@@ -137,7 +137,7 @@ pub fn build_nitro_cli_image(
         },
         vec![output_dir.as_ref()],
         verbose,
-        no_cache
+        no_cache,
     );
 
     let build_image_status =

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -36,6 +36,7 @@ pub async fn build_test_enclave(
         timestamp,
         from_existing,
         reproducible,
+        true
     )
     .await
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -36,7 +36,7 @@ pub async fn build_test_enclave(
         timestamp,
         from_existing,
         reproducible,
-        true
+        true,
     )
     .await
 }


### PR DESCRIPTION
# Why
If a docker image used by the CLI goes into a bad state, there's no recovery beyond clearing docker cache which is a very heavy handed approach.

# How
Add a `no-cache` flag to the CLI to force fresh builds
