### PR TITLE
Remove TLS termination double negative

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -210,10 +210,10 @@ async fn process_dockerfile<R: AsyncRead + std::marker::Unpin>(
         return Err(directive_parse_error);
     }
 
-    let wait_for_env = if build_config.disable_tls_termination {
-        "echo TLS termination is off, not waiting for environment to be ready"
-    } else {
+    let wait_for_env = if build_config.tls_termination {
         r#"while ! grep -q \"EV_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n"#
+    } else {
+        "echo TLS termination is off, not waiting for environment to be ready"
     };
     let user_service_builder =
         crate::docker::utils::create_combined_docker_entrypoint(last_entrypoint, last_cmd).map(
@@ -466,7 +466,7 @@ mod test {
                     not_after: "".into(),
                 },
             },
-            disable_tls_termination: false,
+            tls_termination: true,
             api_key_auth: true,
             trx_logging_enabled: true,
             runtime: None,

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -116,7 +116,7 @@ impl std::convert::From<InitArgs> for EnclaveConfig {
             dockerfile: val.dockerfile.unwrap_or_else(default_dockerfile), // need to manually set default dockerfile
             signing: signing_info,
             attestation: None,
-            disable_tls_termination: val.disable_tls_termination,
+            tls_termination: !val.disable_tls_termination,
             api_key_auth: !val.disable_api_key_auth,
             trx_logging: !val.trx_logging_disabled,
             runtime: None,
@@ -243,7 +243,7 @@ debug = false
 dockerfile = "Dockerfile"
 api_key_auth = true
 trx_logging = true
-disable_tls_termination = false
+tls_termination = true
 forward_proxy_protocol = false
 trusted_headers = ["X-Evervault-*"]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -239,7 +239,7 @@ pub struct EnclaveConfig {
     pub api_key_auth: bool,
     #[serde(default = "default_true")]
     pub trx_logging: bool,
-    #[serde(default)]
+    #[serde(default = "default_true")]
     pub tls_termination: bool,
     #[serde(default)]
     pub forward_proxy_protocol: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -240,7 +240,7 @@ pub struct EnclaveConfig {
     #[serde(default = "default_true")]
     pub trx_logging: bool,
     #[serde(default)]
-    pub disable_tls_termination: bool,
+    pub tls_termination: bool,
     #[serde(default)]
     pub forward_proxy_protocol: bool,
     #[serde(default)]
@@ -282,7 +282,7 @@ pub struct ValidatedEnclaveBuildConfig {
     pub scaling: Option<ScalingSettings>,
     pub signing: ValidatedSigningInfo,
     pub attestation: Option<EIFMeasurements>,
-    pub disable_tls_termination: bool,
+    pub tls_termination: bool,
     pub api_key_auth: bool,
     pub trx_logging_enabled: bool,
     pub runtime: Option<RuntimeVersions>,
@@ -320,8 +320,8 @@ impl ValidatedEnclaveBuildConfig {
         &self.team_uuid
     }
 
-    pub fn disable_tls_termination(&self) -> bool {
-        self.disable_tls_termination
+    pub fn tls_termination(&self) -> bool {
+        self.tls_termination
     }
 
     pub fn get_dataplane_feature_label(&self) -> String {
@@ -330,10 +330,10 @@ impl ValidatedEnclaveBuildConfig {
         } else {
             "egress-disabled"
         };
-        let tls_label = if self.disable_tls_termination {
-            "tls-termination-disabled"
-        } else {
+        let tls_label = if self.tls_termination {
             "tls-termination-enabled"
+        } else {
+            "tls-termination-disabled"
         };
         format!("{egress_label}/{tls_label}")
     }
@@ -471,7 +471,7 @@ impl std::convert::TryFrom<&EnclaveConfig> for ValidatedEnclaveBuildConfig {
             .clone()
             .ok_or_else(|| EnclaveConfigError::MissingField("Team uuid".into()))?;
 
-        let trx_logging_enabled = match (config.trx_logging, !config.disable_tls_termination) {
+        let trx_logging_enabled = match (config.trx_logging, config.tls_termination) {
             (false, _) => Ok(false), // (logging disabled, _) = logging disabled
             (true, false) => Err(EnclaveConfigError::LoggingEnabledWithoutTLSTermination()), // (logging enabled, tls_termination disabled) = config error (Tls termination needed for logging)
             (true, true) => Ok(true), // (logging enabled, tls_termination enabled) = logging enabled
@@ -490,7 +490,7 @@ impl std::convert::TryFrom<&EnclaveConfig> for ValidatedEnclaveBuildConfig {
             signing: signing_info.try_into()?,
             scaling: scaling_settings,
             attestation: config.attestation.clone(),
-            disable_tls_termination: config.disable_tls_termination,
+            tls_termination: config.tls_termination,
             api_key_auth: config.api_key_auth,
             trx_logging_enabled,
             runtime: config.runtime.clone(),
@@ -580,7 +580,7 @@ mod test {
             team_uuid: Some("team_abcdef456".to_string()),
             debug: false,
             dockerfile: "./Dockerfile.config".to_string(),
-            disable_tls_termination: false,
+            tls_termination: true,
             egress: super::EgressSettings {
                 enabled: false,
                 destinations: None,

--- a/test.enclave.toml
+++ b/test.enclave.toml
@@ -6,7 +6,7 @@ debug = false
 dockerfile = "./sample-user.Dockerfile"
 api_key_auth = true
 trx_logging = true
-disable_tls_termination = false
+tls_termination = true
 forward_proxy_protocol = false
 trusted_headers = []
 


### PR DESCRIPTION
# Why
Having `disable` in the config key is confusing

# How
Change from  `disable_tls_termination` to `tls_termination` and flip logic
