### PR TITLE
Migrate command for new major versions

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -447,6 +447,7 @@ mod test {
             enclave_name: "test".into(),
             enclave_uuid: "1234".into(),
             team_uuid: "teamid".into(),
+            version: 1,
             debug: false,
             app_uuid: "3241".into(),
             dockerfile: "".into(),

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -236,7 +236,8 @@ mod init_tests {
         let config_path = output_dir.path().join("enclave.toml");
         assert!(config_path.exists());
         let config_content = String::from_utf8(read(config_path).unwrap()).unwrap();
-        let expected_config_content = r#"name = "hello"
+        let expected_config_content = r#"version = 1
+name = "hello"
 uuid = "1234"
 app_uuid = "1234"
 team_uuid = "1234"

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -107,6 +107,7 @@ impl std::convert::From<InitArgs> for EnclaveConfig {
             uuid: None,
             app_uuid: None,
             team_uuid: None,
+            version: 1,
             debug: val.debug,
 
             egress: EgressSettings::new(convert_comma_list(val.egress_destinations), val.egress),

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,13 +1,17 @@
 use crate::{migrate::migrate_toml, version::check_version};
 use clap::Parser;
 
-/// Build an Enclave from a Dockerfile
+/// Migrate an Enclave toml from v0 to v1
 #[derive(Parser, Debug)]
 #[clap(name = "migrate", about)]
 pub struct MigrateArgs {
     /// Path to the toml file containing the Enclave's config
     #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
     pub config: String,
+
+    /// Path to the new toml created by the migration
+    #[clap(short = 'o', long = "output")]
+    pub output: Option<String>,
 }
 
 pub async fn run(args: MigrateArgs) -> exitcode::ExitCode {
@@ -24,11 +28,70 @@ pub async fn run(args: MigrateArgs) -> exitcode::ExitCode {
         }
     };
 
-    if let Err(e) = std::fs::write(&args.config, serialized_config) {
+    let output_path = match args.output {
+        Some(path) => path,
+        None => args.config.clone(),
+    };
+    if let Err(e) = std::fs::write(&output_path, serialized_config) {
         log::error!("Error writing enclave.toml — {}", e);
         exitcode::IOERR
     } else {
         log::info!("Enclave.toml migrated successfully. You can now deploy a V1 Enclave using the deploy command");
         exitcode::OK
+    }
+}
+
+#[cfg(test)]
+mod migrate_tests {
+
+    use std::fs::read;
+    use tempfile::TempDir;
+
+    use crate::cli::migrate::{run, MigrateArgs};
+
+    #[tokio::test]
+    async fn test_migrate_v0_to_v1() {
+        let output_dir = TempDir::new().unwrap();
+        let output_file = output_dir.path().join("v1.enclave.toml");
+        let args = MigrateArgs {
+            config: "v0.cage.toml".into(),
+            output: Some(output_file.to_str().unwrap().to_string()),
+        };
+        run(args).await;
+        assert!(output_file.exists());
+        let config_content = String::from_utf8(read(output_file).unwrap()).unwrap();
+        let expected_config_content = r#"version = 1
+name = "test-enclave"
+uuid = "1234"
+app_uuid = "4321"
+team_uuid = "teamid"
+debug = false
+dockerfile = "./sample-user.Dockerfile"
+api_key_auth = true
+trx_logging = true
+tls_termination = true
+forward_proxy_protocol = false
+trusted_headers = ["X-Evervault-*"]
+
+[egress]
+enabled = true
+destinations = ["*"]
+
+[signing]
+certPath = "./cert.pem"
+keyPath = "./key.pem"
+
+[attestation]
+HashAlgorithm = "Sha384 { ... }"
+PCR0 = "1cd2135a6358458e390904fac3568eff4e6c7882c22e7925a830c8ba6b9b1ae117dd714cad64b1001475923a242fc887"
+PCR1 = "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f"
+PCR2 = "42997b22af1f96a6b32372402af03a5d16e47316e7990314bdb01c0759fa11a7ae88e3ae2f3628b1c1ab734ea2f2ba34"
+PCR8 = "a94237284c822603176cfe5abbf62664a786b8eef7c5ead7ff725fc2750f06520ce775fec55405ac1837cf2c42e1443a"
+
+[runtime]
+data_plane_version = "0.0.39"
+installer_version = "b8073166b7c5bc8fe2abf192f66e1106f2d4be547b1841be69f95ff2c4ea578c"
+"#;
+        assert_eq!(config_content, expected_config_content);
     }
 }

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,0 +1,34 @@
+use crate::{migrate::migrate_toml, version::check_version};
+use clap::Parser;
+
+/// Build an Enclave from a Dockerfile
+#[derive(Parser, Debug)]
+#[clap(name = "migrate", about)]
+pub struct MigrateArgs {
+    /// Path to the toml file containing the Enclave's config
+    #[clap(short = 'c', long = "config", default_value = "./cage.toml")]
+    pub config: String,
+}
+
+pub async fn run(args: MigrateArgs) -> exitcode::ExitCode {
+    if let Err(e) = check_version().await {
+        log::error!("{}", e);
+        return exitcode::SOFTWARE;
+    };
+
+    let serialized_config = match migrate_toml(&args.config) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            log::error!("{}", e);
+            return exitcode::SOFTWARE;
+        }
+    };
+
+    if let Err(e) = std::fs::write(&args.config, serialized_config) {
+        log::error!("Error writing enclave.toml — {}", e);
+        exitcode::IOERR
+    } else {
+        log::info!("Enclave.toml migrated successfully. You can now deploy a V1 Enclave using the deploy command");
+        exitcode::OK
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,6 +15,7 @@ pub mod env;
 pub mod init;
 pub mod list;
 pub mod logs;
+pub mod migrate;
 pub mod restart;
 pub mod scale;
 pub mod update;
@@ -40,4 +41,5 @@ pub enum Command {
     Encrypt(encrypt::EncryptArgs),
     Restart(restart::RestartArgs),
     Scale(scale::ScaleArgs),
+    Migrate(migrate::MigrateArgs),
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,10 +228,10 @@ pub fn default_true() -> bool {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EnclaveConfig {
+    pub version: u8,
     pub name: String,
     pub uuid: Option<String>,
     pub app_uuid: Option<String>,
-    pub version: u8,
     pub team_uuid: Option<String>,
     pub debug: bool,
     #[serde(default = "default_dockerfile")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod encrypt;
 #[cfg(feature = "internal_dependency")]
 pub mod env;
 pub mod logs;
+pub mod migrate;
 pub mod progress;
 pub mod restart;
 mod version;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ use env_logger::{Builder, Env};
 #[cfg(not(target_os = "windows"))]
 use ev_enclave::cli::attest;
 use ev_enclave::cli::{
-    build, cert, delete, deploy, describe, init, list, logs, restart, scale, update, Command,
+    build, cert, delete, deploy, describe, init, list, logs, migrate, restart, scale, update,
+    Command,
 };
 
 #[cfg(feature = "internal_dependency")]
@@ -67,6 +68,7 @@ async fn main() {
         Command::Encrypt(env_args) => encrypt::run(env_args).await,
         Command::Restart(restart_args) => restart::run(restart_args).await,
         Command::Scale(scale_args) => scale::run(scale_args).await,
+        Command::Migrate(migrate_args) => migrate::run(migrate_args).await,
     };
     std::process::exit(exit_code);
 }

--- a/src/migrate/mod.rs
+++ b/src/migrate/mod.rs
@@ -1,0 +1,32 @@
+use thiserror::Error;
+
+use crate::config::{
+    EnclaveConfig, EnclaveConfigError, EnclaveConfigV0, ValidatedEnclaveBuildConfig,
+};
+
+#[derive(Debug, Error)]
+pub enum MigrateError {
+    #[error("Could not get config at path - {0}")]
+    MissingConfigFile(String),
+    #[error("IO error - {0}")]
+    IOError(#[from] std::io::Error),
+    #[error("Error deserializing existing enclave toml - {0}")]
+    TomlDeError(#[from] toml::de::Error),
+    #[error("Error serializing enclave toml - {0}")]
+    TomlSerError(#[from] toml::ser::Error),
+    #[error("Config is not valid - {0}")]
+    InvalidConfigError(#[from] EnclaveConfigError),
+}
+
+pub fn migrate_toml(config_path: &str) -> Result<Vec<u8>, MigrateError> {
+    let path = std::path::Path::new(config_path);
+    if !path.exists() {
+        return Err(MigrateError::MissingConfigFile(path.display().to_string()));
+    }
+
+    let enclave_config_content = std::fs::read(config_path)?;
+    let v0_config: EnclaveConfigV0 = toml::de::from_slice(enclave_config_content.as_slice())?;
+    let v1_config: EnclaveConfig = v0_config.into();
+    let _: ValidatedEnclaveBuildConfig = v1_config.as_ref().try_into()?;
+    Ok(toml::ser::to_vec(&v1_config)?)
+}

--- a/test.enclave.toml
+++ b/test.enclave.toml
@@ -1,3 +1,4 @@
+version = 1
 name = "test-enclave"
 uuid = "1234"
 app_uuid = "4321"

--- a/v0.cage.toml
+++ b/v0.cage.toml
@@ -1,0 +1,29 @@
+name = "test-enclave"
+uuid = "1234"
+app_uuid = "4321"
+team_uuid = "teamid"
+debug = false
+dockerfile = "./sample-user.Dockerfile"
+api_key_auth = true
+trx_logging = true
+tls_termination = true
+forward_proxy_protocol = false
+trusted_headers = []
+
+[egress]
+enabled = false
+
+[signing]
+certPath = "./cert.pem"
+keyPath = "./key.pem"
+
+[attestation]
+HashAlgorithm = "Sha384 { ... }"
+PCR0 = "1cd2135a6358458e390904fac3568eff4e6c7882c22e7925a830c8ba6b9b1ae117dd714cad64b1001475923a242fc887"
+PCR1 = "bcdf05fefccaa8e55bf2c8d6dee9e79bbff31e34bf28a99aa19e6b29c37ee80b214a414b7607236edf26fcb78654e63f"
+PCR2 = "42997b22af1f96a6b32372402af03a5d16e47316e7990314bdb01c0759fa11a7ae88e3ae2f3628b1c1ab734ea2f2ba34"
+PCR8 = "a94237284c822603176cfe5abbf62664a786b8eef7c5ead7ff725fc2750f06520ce775fec55405ac1837cf2c42e1443a"
+
+[runtime]
+data_plane_version = "0.0.39"
+installer_version = "b8073166b7c5bc8fe2abf192f66e1106f2d4be547b1841be69f95ff2c4ea578c"

--- a/v0.cage.toml
+++ b/v0.cage.toml
@@ -6,12 +6,14 @@ debug = false
 dockerfile = "./sample-user.Dockerfile"
 api_key_auth = true
 trx_logging = true
-tls_termination = true
+disable_tls_termination = false
 forward_proxy_protocol = false
-trusted_headers = []
+trusted_headers = ["X-Evervault-*"]
 
 [egress]
-enabled = false
+enabled = true
+destinations = ["*"]
+ports = ["443"]
 
 [signing]
 certPath = "./cert.pem"


### PR DESCRIPTION
# Why
There will be breaking changes in major versions so we need a command to migrate from one to the next. Currently biased towards v0 -> v1

# How
- convert disable_tls_termination -> tls_termination
- drop egress ports
- Add version to tomls for V1 so we cant start tracking major versions and will be able to easily migrate other versions over time - any tomls without a version will be presumed to be v0
