### PR TITLE
Publish CLI to V1 path for the install script

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -233,7 +233,7 @@ jobs:
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }}
           sh ./scripts/update-versions.sh ${{ inputs.full-version }}
           aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install
-          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/install
+          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/install
           aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/version
           aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/version
           aws s3 cp scripts/versions s3://cage-build-assets-${{ inputs.stage }}/cli/versions


### PR DESCRIPTION
# Why
We cant push the new major version of the CLI to the existing path or else CI builds could unknowingly pull in the new major

# How
Publish main to V1, the V0 release branch will still publish to existing location
