### PR TITLE
Rename property on env add args to value

### DIFF
--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -45,7 +45,7 @@ pub struct AddEnvArgs {
 
     /// Environment variable value
     #[clap(long = "value")]
-    pub secret: String,
+    pub value: String,
 
     /// Is the env var is a secret, it will be encrypted
     #[clap(long = "secret")]

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -29,21 +29,21 @@ pub async fn env(
     match action {
         EnvCommands::Add(command) => {
             let details = get_enclave_details(command.config)?;
-            let env_secret = if command.is_secret {
+            let env_value = if command.is_secret {
                 encrypt(
-                    command.secret,
+                    command.value,
                     details.team_uuid,
                     details.app_uuid,
                     command.curve,
                 )
                 .await?
             } else {
-                command.secret
+                command.value
             };
 
             let request = AddSecretRequest {
                 name: command.name,
-                secret: env_secret,
+                secret: env_value,
             };
             client.add_env_var(details.uuid, request).await?;
             Ok(None)


### PR DESCRIPTION
# Why
Help output for the env add command suggested that all environment variables added were secrets. This is not the case, the `--secret` flag must be explicitly set to encrypt the value

# How
Rename the value attribute name to improve the help output
