### PR TITLE
Add v to path before major version

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -232,9 +232,9 @@ jobs:
         run: |
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }}
           sh ./scripts/update-versions.sh ${{ inputs.full-version }}
-          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/${{ inputs.full-version }}/install
-          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/install
-          aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/${{ inputs.major-version }}/version
+          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/v${{ inputs.major-version }}/${{ inputs.full-version }}/install
+          aws s3 cp scripts/install s3://cage-build-assets-${{ inputs.stage }}/cli/v${{ inputs.major-version }}/install
+          aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/v${{ inputs.major-version }}/version
           aws s3 cp scripts/version s3://cage-build-assets-${{ inputs.stage }}/cli/version
           aws s3 cp scripts/versions s3://cage-build-assets-${{ inputs.stage }}/cli/versions
           aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/cli/install" "/cli/version" "/cli/versions"


### PR DESCRIPTION
# Why
The new cli install script should be accessible at  `enclave-build-assets.evervault.com/cli/v1/install`

# How
Add v to path
