### PR TITLE
Add dep between version and build step in release

### DIFF
--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -41,6 +41,7 @@ jobs:
           result-encoding: string
 
   build-and-deploy:
+    needs: [get-version]
     uses: ./.github/workflows/build-and-publish.yml
     with:
       stage: 'production'


### PR DESCRIPTION
# Why
The build step wasn't waiting for the version so the release failed

# How
Add dependency
