### PR TITLE
Upload the signature during deployment

### DIFF
--- a/crates/ev-enclave/src/api/enclave.rs
+++ b/crates/ev-enclave/src/api/enclave.rs
@@ -341,6 +341,8 @@ pub struct CreateEnclaveDeploymentIntentRequest {
     healthcheck: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     desired_replicas: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pcrs_signature: Option<String>
 }
 
 impl CreateEnclaveDeploymentIntentRequest {
@@ -353,6 +355,7 @@ impl CreateEnclaveDeploymentIntentRequest {
         git_timestamp: String,
         git_hash: String,
         desired_replicas: Option<u32>,
+        pcrs_signature: Option<String>
     ) -> Self {
         Self {
             pcrs: pcrs.clone(),
@@ -371,6 +374,7 @@ impl CreateEnclaveDeploymentIntentRequest {
             },
             healthcheck: config.healthcheck().map(String::from),
             desired_replicas,
+            pcrs_signature
         }
     }
 }

--- a/crates/ev-enclave/src/api/enclave.rs
+++ b/crates/ev-enclave/src/api/enclave.rs
@@ -342,7 +342,7 @@ pub struct CreateEnclaveDeploymentIntentRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     desired_replicas: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pcrs_signature: Option<String>
+    pcrs_signature: Option<String>,
 }
 
 impl CreateEnclaveDeploymentIntentRequest {
@@ -355,7 +355,7 @@ impl CreateEnclaveDeploymentIntentRequest {
         git_timestamp: String,
         git_hash: String,
         desired_replicas: Option<u32>,
-        pcrs_signature: Option<String>
+        pcrs_signature: Option<String>,
     ) -> Self {
         Self {
             pcrs: pcrs.clone(),
@@ -374,7 +374,7 @@ impl CreateEnclaveDeploymentIntentRequest {
             },
             healthcheck: config.healthcheck().map(String::from),
             desired_replicas,
-            pcrs_signature
+            pcrs_signature,
         }
     }
 }

--- a/crates/ev-enclave/src/cli/deploy.rs
+++ b/crates/ev-enclave/src/cli/deploy.rs
@@ -249,22 +249,31 @@ async fn resolve_eif(
 
         /*
          * We cannot guarantee that the signing key pair of the provided EIF are present when it is being uploaded.
-         * We compare the PCRs found in the toml to the PCRs of the EIF (returned by `nitro-cli describe-eif`). 
-         * If the PCRs match, then we know that the signature in the enclave.toml was generated using the key pair which signed this EIF 
+         * We compare the PCRs found in the toml to the PCRs of the EIF (returned by `nitro-cli describe-eif`).
+         * If the PCRs match, then we know that the signature in the enclave.toml was generated using the key pair which signed this EIF
          * and can include the signature in our Deployment request.
          * Otherwise, upload the PCRs without the signature and warn the user.
          */
-        let consistent_pcrs = validated_config.attestation.as_ref()
-          .map(|existing_attestation| existing_attestation.pcrs() == measurements.pcrs())
-          .unwrap_or(false);
+        let consistent_pcrs = validated_config
+            .attestation
+            .as_ref()
+            .map(|existing_attestation| existing_attestation.pcrs() == measurements.pcrs())
+            .unwrap_or(false);
 
         if consistent_pcrs {
-          validated_config.attestation.as_ref().unwrap().signature().map(|signature| {
-            measurements.set_signature(signature.to_string());
-          });
+            validated_config
+                .attestation
+                .as_ref()
+                .unwrap()
+                .signature()
+                .map(|signature| {
+                    measurements.set_signature(signature.to_string());
+                });
         } else {
-          log::warn!("The PCRs in the enclave.toml do not match the PCRs of the EIF provided. The deployment will continue using the PCRs from the EIF.");
-          log::warn!("The signature value in your enclave.toml will not be uploaded to Evervault.");
+            log::warn!("The PCRs in the enclave.toml do not match the PCRs of the EIF provided. The deployment will continue using the PCRs from the EIF.");
+            log::warn!(
+                "The signature value in your enclave.toml will not be uploaded to Evervault."
+            );
         }
 
         Ok((measurements, output_path))

--- a/crates/ev-enclave/src/deploy/mod.rs
+++ b/crates/ev-enclave/src/deploy/mod.rs
@@ -53,7 +53,7 @@ pub async fn deploy_eif<T: EnclaveApi + Clone>(
             .scaling
             .as_ref()
             .map(|config| config.desired_replicas),
-        eif_measurements.signature().map(String::from)
+        eif_measurements.signature().map(String::from),
     );
 
     let deployment_intent = enclave_api

--- a/crates/ev-enclave/src/deploy/mod.rs
+++ b/crates/ev-enclave/src/deploy/mod.rs
@@ -53,6 +53,7 @@ pub async fn deploy_eif<T: EnclaveApi + Clone>(
             .scaling
             .as_ref()
             .map(|config| config.desired_replicas),
+        eif_measurements.signature().map(String::from)
     );
 
     let deployment_intent = enclave_api

--- a/crates/ev-enclave/src/enclave/types.rs
+++ b/crates/ev-enclave/src/enclave/types.rs
@@ -67,6 +67,10 @@ impl EIFMeasurements {
     pub fn set_signature(&mut self, signature: String) {
         self.signature = Some(signature);
     }
+
+    pub fn signature(&self) -> Option<&str> {
+      self.signature.as_deref()
+    }
 }
 
 // Isolated PCRs from remainder of the measures to use in API requests

--- a/crates/ev-enclave/src/enclave/types.rs
+++ b/crates/ev-enclave/src/enclave/types.rs
@@ -69,7 +69,7 @@ impl EIFMeasurements {
     }
 
     pub fn signature(&self) -> Option<&str> {
-      self.signature.as_deref()
+        self.signature.as_deref()
     }
 }
 


### PR DESCRIPTION
# Why
Providing the signature over the PCRs during deployment.

# How
- If the EIF is being built during the deployment, include the new signature in the request payload
- If the EIF is prebuilt, compare its PCRs against the PCRs in the toml. If the PCRs match, upload the signature stored in the toml.
