### PR TITLE
Put PCR signing behind feature flag

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           mkdir ${{ env.BIN_DIR }}
           mkdir ${{ env.RELEASE_DIR }}
-          cross build -p ev-enclave --release --all-features --target ${{ env.LINUX_TARGET }} -Z registry-auth
+          cross build -p ev-enclave --release --features internal_dependency --target ${{ env.LINUX_TARGET }} -Z registry-auth
           mv ./target/${{ env.LINUX_TARGET }}/release/ev-enclave ./${{ env.BIN_DIR }}/ev-enclave
           7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-enclave-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz
         env:
@@ -109,7 +109,7 @@ jobs:
       - name: Build CLI MacOs Target
         run: |
           cargo install cross
-          cross build --release --all-features --target ${{ env.MACOS_TARGET }} -Z registry-auth
+          cross build --release --features internal_dependency --target ${{ env.MACOS_TARGET }} -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.evervault-rust-lib-index }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.evervault-rust-lib-token }}
@@ -168,7 +168,7 @@ jobs:
       - name: Build CLI for Windows
         run: |
           cargo install cross
-          cross build --release --all-features --target ${{ env.WINDOWS_TARGET }} -Z registry-auth
+          cross build --release --features internal_dependency --target ${{ env.WINDOWS_TARGET }} -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.evervault-rust-lib-index }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.evervault-rust-lib-token }}

--- a/.github/workflows/lint-and-test-cli.yml
+++ b/.github/workflows/lint-and-test-cli.yml
@@ -19,7 +19,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Compile project
-        run: cargo build --all-features -Z registry-auth
+        run: cargo build --features internal_dependency -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -17,7 +17,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Compile project
-        run: cargo build --all-features -p ev-enclave -Z registry-auth
+        run: cargo build --features internal_dependency -p ev-enclave -Z registry-auth
         env:
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_INDEX: ${{ secrets.RUST_CRYPTO_REGISTRY }}
           CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}

--- a/crates/ev-enclave/Cargo.toml
+++ b/crates/ev-enclave/Cargo.toml
@@ -46,7 +46,7 @@ git2 = "0.17.1"
 version-compare = "0.1.1"
 regex = "1.8.1"
 semver = "1.0.20"
-pcr-sign = { path = "../pcr-sign" }
+pcr-sign = { path = "../pcr-sign", optional=true }
 elliptic-curve = { version = "0.13.8", features = ["pkcs8"] }
 attestation-doc-validation = "0.7.4"
 
@@ -57,3 +57,4 @@ mockall = "0.11.4"
 
 [features]
 internal_dependency = ["rust-crypto"]
+pcr_signature = ["pcr-sign"]

--- a/crates/ev-enclave/src/build/mod.rs
+++ b/crates/ev-enclave/src/build/mod.rs
@@ -15,9 +15,9 @@ use tokio::fs::File;
 use tokio::io::AsyncRead;
 
 #[cfg(feature = "pcr_signature")]
-use elliptic_curve::{pkcs8::DecodePrivateKey, SecretKey};
-#[cfg(feature = "pcr_signature")]
 use crate::config::SigningInfoError;
+#[cfg(feature = "pcr_signature")]
+use elliptic_curve::{pkcs8::DecodePrivateKey, SecretKey};
 
 const EV_USER_DOCKERFILE_PATH: &str = "enclave.Dockerfile";
 const INSTALLER_DIRECTORY: &str = "/opt/evervault";
@@ -94,24 +94,24 @@ pub async fn build_enclave_image_file(
 
     #[cfg(feature = "pcr_signature")]
     {
-      let private_key =
-          std::fs::read_to_string(signing_info.key()).map_err(SigningInfoError::FileSystemIOError)?;
+        let private_key = std::fs::read_to_string(signing_info.key())
+            .map_err(SigningInfoError::FileSystemIOError)?;
 
-      let signing_key = SecretKey::from_pkcs8_pem(private_key.as_str())
-          .map(|secret_key| secret_key.into())
-          .map_err(|e| SigningInfoError::InvalidKey {
-              curve: "p384r1".into(),
-              inner: e,
-          })?;
+        let signing_key = SecretKey::from_pkcs8_pem(private_key.as_str())
+            .map(|secret_key| secret_key.into())
+            .map_err(|e| SigningInfoError::InvalidKey {
+                curve: "p384r1".into(),
+                inner: e,
+            })?;
 
-      let pcrs_signature = pcr_sign::Signature::new(
-          pcr_sign::SignatureVersion::default(),
-          built_enclave.measurements().pcrs(),
-          signing_key,
-      );
-      let signature = pcrs_signature.sign();
+        let pcrs_signature = pcr_sign::Signature::new(
+            pcr_sign::SignatureVersion::default(),
+            built_enclave.measurements().pcrs(),
+            signing_key,
+        );
+        let signature = pcrs_signature.sign();
 
-      built_enclave.measurements_mut().set_signature(signature);
+        built_enclave.measurements_mut().set_signature(signature);
     }
 
     Ok((built_enclave, output_path))

--- a/crates/ev-enclave/src/enclave/types.rs
+++ b/crates/ev-enclave/src/enclave/types.rs
@@ -86,6 +86,7 @@ pub struct PCRs {
     pub pcr8: Option<String>,
 }
 
+#[cfg(feature = "pcr_signature")]
 impl pcr_sign::PCRProvider for PCRs {
     fn pcr0(&self) -> &str {
         &self.pcr0


### PR DESCRIPTION
# Why
The new pcr signing feature has introduced errors for enclave builds due to errors parsing keys. The signature is not being consumed yet, so can be safely removed until the parsing errors are resolved.

# How
Add new feature flag for PCR signing, disabled by default. Update all workflows to explicitly use the internal dependency feature flag, and omit the new pcr signature flag.
