### PR TITLE
Add notice on docker engine compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,8 @@ The Evervault Enclaves product is open source with the aim of providing transpar
 
 The current state of this project does not allow for self-hosting. We plan on addressing this by abstracting away the Evervault-specific elements of the Enclaves product.
 
+## Known Issues
+
+The Enclaves CLI is incompatible with Docker Engine >= 25.0.0. This is due to a change in the Docker Engine API v1.44 becoming incompatible with a dependency used within the Nitro CLI. We are working to rectify this issue.
+
 Learn more in the [docs](https://docs.evervault.com/primitives/enclaves)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ The Evervault Enclaves product is open source with the aim of providing transpar
 
 The current state of this project does not allow for self-hosting. We plan on addressing this by abstracting away the Evervault-specific elements of the Enclaves product.
 
+Learn more in the [docs](https://docs.evervault.com/primitives/enclaves)
+
 ## Known Issues
 
-The Enclaves CLI is incompatible with Docker Engine >= 25.0.0. This is due to a change in the Docker Engine API v1.44 becoming incompatible with a dependency used within the Nitro CLI. We are working to rectify this issue.
+The Enclaves CLI is incompatible with Docker Engine >= 25.0.0. This is due to a change in the Docker Engine API v1.44 becoming incompatible with a dependency used within the Nitro CLI. We are working to rectify this issue. 
 
-Learn more in the [docs](https://docs.evervault.com/primitives/enclaves)
+More information on this issue can be found [here](https://github.com/aws/aws-nitro-enclaves-cli/issues/537).


### PR DESCRIPTION
# Why
Latest docker engine is not compatible with the Enclaves CLI as it currently stands.

# How
Add notice on the incompatibility with new Docker Engine versions
