### PR TITLE
Build auto-deriving impl for CliMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,18 +200,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -540,7 +540,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -559,6 +559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "cli-message"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +578,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cli-message",
  "elliptic-curve 0.13.8",
  "exitcode",
  "mockall",
@@ -747,7 +757,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -758,7 +768,7 @@ checksum = "1d1545d67a2149e1d93b7e5c7752dce5a7426eb5d1357ddcfd89336b94444f77"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -886,7 +896,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1018,10 +1028,12 @@ dependencies = [
 name = "ev-cli"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "attestation-doc-validation",
  "atty",
  "chrono",
  "clap 4.5.4",
+ "cli-message",
  "common",
  "dialoguer",
  "env_logger",
@@ -1223,7 +1235,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1958,7 +1970,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2113,7 +2125,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2258,18 +2270,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2327,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2619,7 +2631,7 @@ checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2641,7 +2653,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2699,7 +2711,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2724,7 +2736,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -2885,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2986,7 +2998,7 @@ checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3060,7 +3072,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -3382,7 +3394,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
  "wasm-bindgen-shared",
 ]
 
@@ -3416,7 +3428,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3686,7 +3698,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.63",
 ]
 
 [[package]]

--- a/crates/cli-message/Cargo.toml
+++ b/crates/cli-message/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cli-message"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proc-macro2 = "1.0.82"
+quote = "1.0.36"
+syn = "2.0.63"
+
+[lib]
+proc-macro = true

--- a/crates/cli-message/src/error.rs
+++ b/crates/cli-message/src/error.rs
@@ -1,0 +1,55 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+#[derive(Debug)]
+pub enum ParseMessageError {
+    MissingMessageAttribute,
+    FieldSetTwice,
+    ExitCodeParse(std::num::ParseIntError),
+    UnknownIdent,
+    LiteralWithoutIdent,
+    UnsupportedDerived,
+}
+
+pub fn compile_error_from_parse_error(
+    variant_name: String,
+    err: &ParseMessageError,
+) -> TokenStream2 {
+    let msg = match err {
+        ParseMessageError::MissingMessageAttribute => {
+            format!(
+                "{} contains variants which do not have a message attribute. \
+            All variants in an enum deriving the CliMessage trait must have a message attribute.",
+                variant_name
+            )
+        }
+        ParseMessageError::FieldSetTwice => {
+            format!(
+                "Subattribute of Message attribute set twice for variant {}",
+                variant_name
+            )
+        }
+        ParseMessageError::ExitCodeParse(parse_err) => {
+            format!(
+                "Failed to parse provided exit code for variant to i32: {}",
+                parse_err
+            )
+        }
+        ParseMessageError::UnknownIdent => {
+            format!("Unknown ident for variant: {}", variant_name)
+        }
+        ParseMessageError::LiteralWithoutIdent => {
+            format!("Sub Attributes must be directly specified, positional arguments are not specified {}",
+                variant_name)
+        }
+        ParseMessageError::UnsupportedDerived => {
+            format!(
+                "Attempted to derive CliMessage on an unsupported type only enums are supported"
+            )
+        }
+    };
+
+    quote! {
+        compile_error!(#msg);
+    }
+}

--- a/crates/cli-message/src/lib.rs
+++ b/crates/cli-message/src/lib.rs
@@ -1,0 +1,292 @@
+extern crate proc_macro;
+
+use std::collections::HashMap;
+
+use proc_macro::TokenStream;
+
+use proc_macro2::{TokenStream as TokenStream2, TokenTree};
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Ident, Meta};
+
+#[derive(Debug)]
+struct ImMessage {
+    content: Option<String>,
+    code: Option<String>,
+    exit_code: Option<i32>,
+}
+
+struct Message {
+    content: String,
+    code: String,
+    exit_code: i32,
+}
+
+#[derive(Debug)]
+enum ParseMessageError {
+    MessageNotSet,
+    FieldSetTwice,
+    FailedToParseExitCode(std::num::ParseIntError),
+    UnknownIdent,
+}
+
+fn parse_message_attribute(toks: TokenStream2) -> Result<ImMessage, ParseMessageError> {
+    let mut im = ImMessage {
+        content: None,
+        code: None,
+        exit_code: None,
+    };
+    let mut last_ident: Option<String> = None;
+
+    fn set_opt_once<T>(opt: &mut Option<T>, val: T) -> Result<(), ParseMessageError> {
+        if opt.is_some() {
+            return Err(ParseMessageError::FieldSetTwice);
+        }
+
+        *opt = Some(val);
+        Ok(())
+    }
+
+    for (i, tok) in toks.into_iter().enumerate() {
+        match tok {
+            TokenTree::Literal(lit) => {
+                let lit = lit.to_string().replace("\"", "");
+
+                // handle the default case where content is first arg
+                if i == 0 {
+                    im.content = Some(lit);
+                    last_ident = None;
+                    continue;
+                }
+
+                if let Some(ident) = last_ident {
+                    match ident.as_str() {
+                        "message" => set_opt_once(&mut im.content, lit)?,
+                        "code" => set_opt_once(&mut im.code, lit)?,
+                        "exit_code" => {
+                            let exit_code: i32 = lit
+                                .parse()
+                                .map_err(|e| ParseMessageError::FailedToParseExitCode(e))?;
+                            set_opt_once(&mut im.exit_code, exit_code)?
+                        }
+                        &_ => return Err(ParseMessageError::UnknownIdent),
+                    }
+                }
+
+                last_ident = None;
+            }
+            TokenTree::Ident(ident) => {
+                last_ident = Some(ident.to_string());
+
+                match ident.to_string().as_str() {
+                    "message" | "code" | "exit_code" => last_ident = Some(ident.to_string()),
+                    &_ => {}
+                }
+            }
+            _ => continue,
+        }
+    }
+
+    Ok(im)
+}
+
+fn build_message_code_from_enum(enum_name: String, variant_name: String) -> String {
+    format!(
+        "{}-{}",
+        to_kebab_case(enum_name),
+        to_kebab_case(variant_name)
+    )
+}
+
+fn to_kebab_case(s: String) -> String {
+    let mut kebab = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if i != 0 && c.is_uppercase() {
+            kebab.push('-');
+        }
+        // should only be one chat unless weird chars are used in enums (which is usually a compile
+        // error)
+        c.to_lowercase()
+            .for_each(|lowercased| kebab.push(lowercased));
+    }
+    kebab
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn it_can_extract_the_message_as_default_argument() {
+        let toks = TokenStream2::from_str("\"Hello World\"").unwrap();
+        let parsed = parse_message_attribute(toks).unwrap();
+        assert_eq!(parsed.message.unwrap(), "Hello World");
+    }
+
+    #[test]
+    fn it_can_extract_specified_message() {
+        let toks = TokenStream2::from_str("message=\"Hello World\"").unwrap();
+        let parsed = parse_message_attribute(toks).unwrap();
+        assert_eq!(parsed.message.unwrap(), "Hello World");
+    }
+
+    #[test]
+    fn it_can_extract_exit_code() {
+        let toks = TokenStream2::from_str("exit_code=\"0\"").unwrap();
+        let parsed = parse_message_attribute(toks);
+        assert_eq!(parsed.unwrap().exit_code.unwrap(), 0);
+
+        // let toks = TokenStream2::from_str("message = \"test\"\\, exit_code=\"5\"");
+        // println!("{:?}", toks);
+        // let parsed = parse_message_attribute(toks.unwrap()).unwrap();
+        // assert_eq!(parsed.exit_code.unwrap(), 5);
+        // assert_eq!(parsed.message.unwrap(), "\"test\"".to_string());
+    }
+}
+
+fn compile_error_from_parse_error(variant_name: String, err: &ParseMessageError) -> TokenStream2 {
+    let msg = match err {
+        ParseMessageError::MessageNotSet => {
+            format!("Message not set for variant: {}", variant_name)
+        }
+        ParseMessageError::FieldSetTwice => {
+            format!("Message set twice for variant: {}", variant_name)
+        }
+        ParseMessageError::FailedToParseExitCode(parse_err) => {
+            format!("Failed to parse exit code for variant: {}", parse_err)
+        }
+        ParseMessageError::UnknownIdent => {
+            format!("Unknown ident for variant: {}", variant_name)
+        }
+    };
+
+    quote! {
+        compile_error!(#msg);
+    }
+}
+
+/// Performs automatic implementation of the CliMessage trait for an enum
+///
+/// # Example
+///
+/// #[derive(CliMessage)]
+/// pub enum RelayCreate {
+///    #[message("Relay created successfully")]
+///    Success,
+///    #[message("A relay with this domain already exists")]
+///    AlreadyExists,
+///
+/// }
+#[proc_macro_derive(CliMessage, attributes(message))]
+pub fn cli_message_derive(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = parse_macro_input!(input);
+    let name = &input.ident;
+
+    let data = match input.data {
+        Data::Enum(data_enum) => data_enum,
+        _ => {
+            return quote! {
+                compile_error!("CliMessage can only be derived for enums");
+            }
+            .into()
+        }
+    };
+
+    let variants: Vec<Result<(&Ident, Message), ParseMessageError>> = data
+        .variants
+        .iter()
+        .filter_map(|variant| {
+            let variant_name = &variant.ident;
+            let message_attr = variant.attrs.iter().find_map(|attr| {
+                if let Meta::List(parts) = &attr.meta {
+                    if parts.path.is_ident("message") {
+                        return Some(parts);
+                    }
+                }
+                None
+            })?;
+
+            println!("{:#?}", variant);
+            let im = match parse_message_attribute(message_attr.tokens.clone()) {
+                Ok(im) => im,
+                Err(e) => return Some(Err(e)),
+            };
+
+            // message content is the only field we can't infer
+            let content = match im.content {
+                Some(content) => content,
+                None => return Some(Err(ParseMessageError::MessageNotSet)),
+            };
+
+            let message = Message {
+                content,
+                code: im.code.unwrap_or_else(|| {
+                    // build_message_code_from_enum(name.to_string(), variant_name.to_string())
+                    "test".to_string()
+                }),
+                exit_code: im.exit_code.unwrap_or(0),
+            };
+
+            Some(Ok((variant_name, message)))
+        })
+        .collect();
+
+    let mut tokens = HashMap::from([("content", vec![]), ("code", vec![]), ("exit_code", vec![])]);
+
+    for variant in variants {
+        match variant {
+            Ok((variant_name, message)) => {
+                let content = message.content;
+                let code = message.code;
+                let exit_code = message.exit_code;
+
+                tokens.entry("content").and_modify(|v| {
+                    v.push(quote! {
+                        #name::#variant_name => #content.to_string()
+                    })
+                });
+
+                tokens.entry("code").and_modify(|v| {
+                    v.push(quote! {
+                        #name::#variant_name => #code.to_string()
+                    })
+                });
+
+                tokens.entry("exit_code").and_modify(|v| {
+                    v.push(quote! {
+                        #name::#variant_name => #exit_code
+                    })
+                });
+            }
+            Err(e) => return compile_error_from_parse_error(name.to_string(), &e).into(),
+        }
+    }
+
+    let messages = tokens.get("content").expect("infallible");
+    let codes = tokens.get("code").expect("infallible");
+    let exit_codes = tokens.get("exit_code").expect("infallible");
+
+    quote! {
+        impl CliMessage for #name {
+            fn message(&self) -> String {
+                match self {
+                    #(#messages),*
+                }
+            }
+
+            fn code(&self) -> String {
+                match self {
+                    #(#codes),*
+                }
+            }
+
+            fn exit_code(&self) -> i32 {
+                match self {
+                    #(#exit_codes),*
+                }
+            }
+        }
+    }
+    .into()
+}

--- a/crates/cli-message/src/lib.rs
+++ b/crates/cli-message/src/lib.rs
@@ -1,274 +1,51 @@
 extern crate proc_macro;
 
-use std::collections::HashMap;
-
 use proc_macro::TokenStream;
 
-use proc_macro2::{TokenStream as TokenStream2, TokenTree};
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Ident, Meta};
+use syn::{parse_macro_input, Data, DeriveInput, Meta, Variant};
 
-#[derive(Debug)]
-struct ImMessage {
-    content: Option<String>,
-    code: Option<String>,
-    exit_code: Option<i32>,
-}
+mod error;
+mod parse;
+mod tok;
 
-struct Message {
-    content: String,
-    code: String,
-    exit_code: i32,
-}
+use crate::parse::derive_message_from_im;
+use error::ParseMessageError;
+use parse::{parse_message_attribute, Message};
+use tok::build_match_arm_toks;
 
-#[derive(Debug)]
-enum ParseMessageError {
-    MessageNotSet,
-    FieldSetTwice,
-    FailedToParseExitCode(std::num::ParseIntError),
-    UnknownIdent,
-}
+fn impl_enum(
+    data: syn::DataEnum,
+    enum_name: &syn::Ident,
+) -> Result<TokenStream2, ParseMessageError> {
+    let mut variants_with_message: Vec<(&Variant, Message)> = Vec::new();
 
-fn parse_message_attribute(toks: TokenStream2) -> Result<ImMessage, ParseMessageError> {
-    let mut im = ImMessage {
-        content: None,
-        code: None,
-        exit_code: None,
-    };
-    let mut last_ident: Option<String> = None;
-
-    fn set_opt_once<T>(opt: &mut Option<T>, val: T) -> Result<(), ParseMessageError> {
-        if opt.is_some() {
-            return Err(ParseMessageError::FieldSetTwice);
-        }
-
-        *opt = Some(val);
-        Ok(())
-    }
-
-    for (i, tok) in toks.into_iter().enumerate() {
-        match tok {
-            TokenTree::Literal(lit) => {
-                let lit = lit.to_string().replace("\"", "");
-
-                // handle the default case where content is first arg
-                if i == 0 {
-                    im.content = Some(lit);
-                    last_ident = None;
-                    continue;
-                }
-
-                if let Some(ident) = last_ident {
-                    match ident.as_str() {
-                        "message" => set_opt_once(&mut im.content, lit)?,
-                        "code" => set_opt_once(&mut im.code, lit)?,
-                        "exit_code" => {
-                            let exit_code: i32 = lit
-                                .parse()
-                                .map_err(|e| ParseMessageError::FailedToParseExitCode(e))?;
-                            set_opt_once(&mut im.exit_code, exit_code)?
-                        }
-                        &_ => return Err(ParseMessageError::UnknownIdent),
-                    }
-                }
-
-                last_ident = None;
-            }
-            TokenTree::Ident(ident) => {
-                last_ident = Some(ident.to_string());
-
-                match ident.to_string().as_str() {
-                    "message" | "code" | "exit_code" => last_ident = Some(ident.to_string()),
-                    &_ => {}
-                }
-            }
-            _ => continue,
-        }
-    }
-
-    Ok(im)
-}
-
-fn build_message_code_from_enum(enum_name: String, variant_name: String) -> String {
-    format!(
-        "{}-{}",
-        to_kebab_case(enum_name),
-        to_kebab_case(variant_name)
-    )
-}
-
-fn to_kebab_case(s: String) -> String {
-    let mut kebab = String::new();
-    for (i, c) in s.chars().enumerate() {
-        if i != 0 && c.is_uppercase() {
-            kebab.push('-');
-        }
-        // should only be one chat unless weird chars are used in enums (which is usually a compile
-        // error)
-        c.to_lowercase()
-            .for_each(|lowercased| kebab.push(lowercased));
-    }
-    kebab
-}
-
-#[cfg(test)]
-mod tests {
-    use std::str::FromStr;
-
-    use super::*;
-
-    #[test]
-    fn it_can_extract_the_message_as_default_argument() {
-        let toks = TokenStream2::from_str("\"Hello World\"").unwrap();
-        let parsed = parse_message_attribute(toks).unwrap();
-        assert_eq!(parsed.message.unwrap(), "Hello World");
-    }
-
-    #[test]
-    fn it_can_extract_specified_message() {
-        let toks = TokenStream2::from_str("message=\"Hello World\"").unwrap();
-        let parsed = parse_message_attribute(toks).unwrap();
-        assert_eq!(parsed.message.unwrap(), "Hello World");
-    }
-
-    #[test]
-    fn it_can_extract_exit_code() {
-        let toks = TokenStream2::from_str("exit_code=\"0\"").unwrap();
-        let parsed = parse_message_attribute(toks);
-        assert_eq!(parsed.unwrap().exit_code.unwrap(), 0);
-
-        // let toks = TokenStream2::from_str("message = \"test\"\\, exit_code=\"5\"");
-        // println!("{:?}", toks);
-        // let parsed = parse_message_attribute(toks.unwrap()).unwrap();
-        // assert_eq!(parsed.exit_code.unwrap(), 5);
-        // assert_eq!(parsed.message.unwrap(), "\"test\"".to_string());
-    }
-}
-
-fn compile_error_from_parse_error(variant_name: String, err: &ParseMessageError) -> TokenStream2 {
-    let msg = match err {
-        ParseMessageError::MessageNotSet => {
-            format!("Message not set for variant: {}", variant_name)
-        }
-        ParseMessageError::FieldSetTwice => {
-            format!("Message set twice for variant: {}", variant_name)
-        }
-        ParseMessageError::FailedToParseExitCode(parse_err) => {
-            format!("Failed to parse exit code for variant: {}", parse_err)
-        }
-        ParseMessageError::UnknownIdent => {
-            format!("Unknown ident for variant: {}", variant_name)
-        }
-    };
-
-    quote! {
-        compile_error!(#msg);
-    }
-}
-
-/// Performs automatic implementation of the CliMessage trait for an enum
-///
-/// # Example
-///
-/// #[derive(CliMessage)]
-/// pub enum RelayCreate {
-///    #[message("Relay created successfully")]
-///    Success,
-///    #[message("A relay with this domain already exists")]
-///    AlreadyExists,
-///
-/// }
-#[proc_macro_derive(CliMessage, attributes(message))]
-pub fn cli_message_derive(input: TokenStream) -> TokenStream {
-    let input: DeriveInput = parse_macro_input!(input);
-    let name = &input.ident;
-
-    let data = match input.data {
-        Data::Enum(data_enum) => data_enum,
-        _ => {
-            return quote! {
-                compile_error!("CliMessage can only be derived for enums");
-            }
-            .into()
-        }
-    };
-
-    let variants: Vec<Result<(&Ident, Message), ParseMessageError>> = data
-        .variants
-        .iter()
-        .filter_map(|variant| {
-            let variant_name = &variant.ident;
-            let message_attr = variant.attrs.iter().find_map(|attr| {
+    for variant in data.variants.iter() {
+        let message_attr = variant
+            .attrs
+            .iter()
+            .find_map(|attr| {
                 if let Meta::List(parts) = &attr.meta {
                     if parts.path.is_ident("message") {
                         return Some(parts);
                     }
                 }
                 None
-            })?;
+            })
+            .ok_or(())
+            .map_err(|_| ParseMessageError::MissingMessageAttribute)?;
 
-            println!("{:#?}", variant);
-            let im = match parse_message_attribute(message_attr.tokens.clone()) {
-                Ok(im) => im,
-                Err(e) => return Some(Err(e)),
-            };
+        let im = parse_message_attribute(message_attr.tokens.clone())?;
+        let message = derive_message_from_im(im, enum_name.to_string(), variant.ident.to_string())?;
 
-            // message content is the only field we can't infer
-            let content = match im.content {
-                Some(content) => content,
-                None => return Some(Err(ParseMessageError::MessageNotSet)),
-            };
-
-            let message = Message {
-                content,
-                code: im.code.unwrap_or_else(|| {
-                    // build_message_code_from_enum(name.to_string(), variant_name.to_string())
-                    "test".to_string()
-                }),
-                exit_code: im.exit_code.unwrap_or(0),
-            };
-
-            Some(Ok((variant_name, message)))
-        })
-        .collect();
-
-    let mut tokens = HashMap::from([("content", vec![]), ("code", vec![]), ("exit_code", vec![])]);
-
-    for variant in variants {
-        match variant {
-            Ok((variant_name, message)) => {
-                let content = message.content;
-                let code = message.code;
-                let exit_code = message.exit_code;
-
-                tokens.entry("content").and_modify(|v| {
-                    v.push(quote! {
-                        #name::#variant_name => #content.to_string()
-                    })
-                });
-
-                tokens.entry("code").and_modify(|v| {
-                    v.push(quote! {
-                        #name::#variant_name => #code.to_string()
-                    })
-                });
-
-                tokens.entry("exit_code").and_modify(|v| {
-                    v.push(quote! {
-                        #name::#variant_name => #exit_code
-                    })
-                });
-            }
-            Err(e) => return compile_error_from_parse_error(name.to_string(), &e).into(),
-        }
+        variants_with_message.push((variant, message));
     }
 
-    let messages = tokens.get("content").expect("infallible");
-    let codes = tokens.get("code").expect("infallible");
-    let exit_codes = tokens.get("exit_code").expect("infallible");
+    let (messages, codes, exit_codes) = build_match_arm_toks(variants_with_message, &enum_name);
 
-    quote! {
-        impl CliMessage for #name {
+    Ok(quote! {
+        impl CliMessage for #enum_name {
             fn message(&self) -> String {
                 match self {
                     #(#messages),*
@@ -287,6 +64,21 @@ pub fn cli_message_derive(input: TokenStream) -> TokenStream {
                 }
             }
         }
+    })
+}
+
+/// Performs automatic implementation of the CliMessage trait for an enum
+#[proc_macro_derive(CliMessage, attributes(message, code, status_code))]
+pub fn cli_message_derive(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = parse_macro_input!(input);
+
+    let toks = match input.data {
+        Data::Enum(data_enum) => impl_enum(data_enum, &input.ident),
+        _ => Err(ParseMessageError::UnsupportedDerived),
+    };
+
+    match toks {
+        Ok(toks) => TokenStream::from(toks),
+        Err(err) => error::compile_error_from_parse_error(input.ident.to_string(), &err).into(),
     }
-    .into()
 }

--- a/crates/cli-message/src/lib.rs
+++ b/crates/cli-message/src/lib.rs
@@ -68,6 +68,25 @@ fn impl_enum(
 }
 
 /// Performs automatic implementation of the CliMessage trait for an enum
+///
+/// Supports magic derive for message codes, so an enum variant `RelayCreate::Success`
+/// will derive a message code of `relay-create-success`.
+/// This is a direct PascalCase -> kebab-case conversion.
+///
+/// ### Example Usage
+/// ```ignore
+/// #[derive(CliMessage)]
+/// pub enum RelayCreate {
+///    #[message("Relay created successfully")]
+///    Success,
+///    #[message("A relay with the domain {} already exists")]
+///    AlreadyExists(String),
+///    #[message("Docker service isn't running", exit_code = exitcode::UNAVAILABLE)]
+///    DockerNotRunning,
+///    #message("Failed to create relay", code = "relay-failed", exit_code = 1)
+/// }
+/// ```
+///
 #[proc_macro_derive(CliMessage, attributes(message, code, status_code))]
 pub fn cli_message_derive(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);

--- a/crates/cli-message/src/lib.rs
+++ b/crates/cli-message/src/lib.rs
@@ -83,7 +83,8 @@ fn impl_enum(
 ///    AlreadyExists(String),
 ///    #[message("Docker service isn't running", exit_code = exitcode::UNAVAILABLE)]
 ///    DockerNotRunning,
-///    #message("Failed to create relay", code = "relay-failed", exit_code = 1)
+///    #[message("Domain name is too long", code = "too-long")]
+///    TooLong
 /// }
 /// ```
 ///

--- a/crates/cli-message/src/parse.rs
+++ b/crates/cli-message/src/parse.rs
@@ -1,0 +1,228 @@
+use proc_macro2::{TokenStream as TokenStream2, TokenTree};
+
+use crate::error::ParseMessageError;
+
+// The parser intermediate representation of the Message struct
+#[derive(Debug)]
+pub struct ImMessage {
+    pub content: Option<String>,
+    pub code: Option<String>,
+    pub exit_code: Option<i32>,
+}
+
+// Holds the desired outputs of the CliMessage trait whilst generating
+// the tokens necessary for the impl
+pub struct Message {
+    pub content: String,
+    pub code: String,
+    pub exit_code: i32,
+}
+
+fn build_message_code_from_enum(enum_name: String, variant_name: String) -> String {
+    format!(
+        "{}-{}",
+        to_kebab_case(enum_name),
+        to_kebab_case(variant_name)
+    )
+}
+
+fn to_kebab_case(s: String) -> String {
+    s.chars()
+        .enumerate()
+        .map(|(i, c)| {
+            if i > 0 && c.is_uppercase() {
+                format!("-{}", c.to_lowercase())
+            } else {
+                c.to_lowercase().to_string()
+            }
+        })
+        .collect::<String>()
+}
+
+enum SubAttr {
+    Message,
+    Code,
+    ExitCode,
+}
+
+impl TryFrom<proc_macro2::Ident> for SubAttr {
+    type Error = ParseMessageError;
+
+    fn try_from(ident: proc_macro2::Ident) -> Result<Self, Self::Error> {
+        match ident.to_string().as_str() {
+            "message" => Ok(SubAttr::Message),
+            "code" => Ok(SubAttr::Code),
+            "exit_code" => Ok(SubAttr::ExitCode),
+            _ => Err(ParseMessageError::UnknownIdent),
+        }
+    }
+}
+
+// Parses the token stream contained in wrapping parentheses of the message attr
+// ie #[message(<token-stream>)]
+pub fn parse_message_attribute(toks: TokenStream2) -> Result<ImMessage, ParseMessageError> {
+    println!("{:?}", toks.to_string());
+    let mut im = ImMessage {
+        content: None,
+        code: None,
+        exit_code: None,
+    };
+    let mut ident_being_parsed: Option<SubAttr> = None;
+
+    fn set_opt_once<T>(opt: &mut Option<T>, val: T) -> Result<(), ParseMessageError> {
+        if opt.is_some() {
+            return Err(ParseMessageError::FieldSetTwice);
+        }
+
+        *opt = Some(val);
+        Ok(())
+    }
+
+    for (i, tok) in toks.into_iter().enumerate() {
+        match tok {
+            TokenTree::Literal(lit) => {
+                let lit = lit.to_string().replace("\"", "");
+
+                // handle the default case where content is first arg
+                if i == 0 {
+                    im.content = Some(lit);
+                    ident_being_parsed = None;
+                    continue;
+                }
+
+                if let Some(ident) = ident_being_parsed {
+                    match ident {
+                        SubAttr::Message => set_opt_once(&mut im.content, lit)?,
+                        SubAttr::Code => set_opt_once(&mut im.code, lit)?,
+                        SubAttr::ExitCode => {
+                            let exit_code: i32 = lit
+                                .parse()
+                                .map_err(|e| ParseMessageError::ExitCodeParse(e))?;
+                            set_opt_once(&mut im.exit_code, exit_code)?;
+                        }
+                    }
+                } else {
+                    return Err(ParseMessageError::LiteralWithoutIdent);
+                }
+
+                ident_being_parsed = None;
+            }
+            TokenTree::Ident(ident) => {
+                ident_being_parsed = Some(SubAttr::try_from(ident)?);
+            }
+            _ => continue,
+        }
+    }
+
+    Ok(im)
+}
+
+pub fn derive_message_from_im(
+    im: ImMessage,
+    enum_name: String,
+    variant_name: String,
+) -> Result<Message, ParseMessageError> {
+    let content = match im.content {
+        Some(content) => content,
+        None => return Err(ParseMessageError::MissingMessageAttribute),
+    };
+
+    Ok(Message {
+        content,
+        code: im.code.unwrap_or_else(|| {
+            build_message_code_from_enum(enum_name.to_string(), variant_name.to_string())
+        }),
+        exit_code: im.exit_code.unwrap_or(0),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn it_can_extract_the_message_as_default_argument() {
+        let toks = TokenStream2::from_str("\"Hello World\"").unwrap();
+        let parsed = parse_message_attribute(toks).unwrap();
+        assert_eq!(parsed.content.unwrap(), "Hello World");
+    }
+
+    #[test]
+    fn it_can_extract_specified_message() {
+        let toks = TokenStream2::from_str("message=\"Hello World\"").unwrap();
+        let parsed = parse_message_attribute(toks).unwrap();
+        assert_eq!(parsed.content.unwrap(), "Hello World");
+    }
+
+    #[test]
+    fn it_can_extract_exit_code() {
+        let toks = TokenStream2::from_str("exit_code=\"0\"").unwrap();
+        let parsed = parse_message_attribute(toks);
+        assert_eq!(parsed.unwrap().exit_code.unwrap(), 0);
+
+        let toks = TokenStream2::from_str("message = \"test\", exit_code = \"5\"");
+        println!("{:?}", toks);
+        let parsed = parse_message_attribute(toks.unwrap()).unwrap();
+        assert_eq!(parsed.exit_code.unwrap(), 5);
+        assert_eq!(parsed.content.unwrap(), "test".to_string());
+    }
+
+    #[test]
+    fn it_can_extract_code() {
+        let toks = TokenStream2::from_str("code=\"test\"").unwrap();
+        let parsed = parse_message_attribute(toks).unwrap();
+        assert_eq!(parsed.code.unwrap(), "test");
+    }
+
+    #[test]
+    fn it_errors_on_multiple_message_fields_with_default() {
+        let toks = TokenStream2::from_str("\"Hello World\", message=\"Hello World\"");
+        let parsed = parse_message_attribute(toks.unwrap());
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn it_errors_on_multiple_fields() {
+        let toks = TokenStream2::from_str("message=\"Hello World\", message=\"Hello World\"");
+        let parsed = parse_message_attribute(toks.unwrap());
+        assert!(parsed.is_err());
+
+        let toks = TokenStream2::from_str("code=\"Hello World\", code=\"test\"");
+        let parsed = parse_message_attribute(toks.unwrap());
+        assert!(parsed.is_err());
+
+        let toks = TokenStream2::from_str("exit_code=\"0\", exit_code=\"5\"");
+        let parsed = parse_message_attribute(toks.unwrap());
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn it_errors_on_unknown_ident() {
+        let toks = TokenStream2::from_str("unknown=\"Hello World\"");
+        let parsed = parse_message_attribute(toks.unwrap());
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn it_converts_to_kebab_case() {
+        assert_eq!(
+            build_message_code_from_enum("RelayCreate".into(), "Success".into()),
+            "relay-create-success"
+        );
+
+        assert_eq!(to_kebab_case("RelayCreate".into()), "relay-create");
+        assert_eq!(
+            to_kebab_case("RelayCreateSuccess".into()),
+            "relay-create-success"
+        );
+    }
+
+    #[test]
+    fn it_errors_on_raw_literals() {
+        let toks = TokenStream2::from_str("=Hello World");
+        let parsed = parse_message_attribute(toks.unwrap());
+        assert!(parsed.is_err());
+    }
+}

--- a/crates/cli-message/src/tok.rs
+++ b/crates/cli-message/src/tok.rs
@@ -1,0 +1,84 @@
+use std::collections::HashMap;
+
+use quote::{format_ident, quote};
+use syn::Fields;
+
+use crate::parse::Message;
+
+// contains the tokens for each match arm
+type SubAttrToks = (
+    Vec<proc_macro2::TokenStream>,
+    Vec<proc_macro2::TokenStream>,
+    Vec<proc_macro2::TokenStream>,
+);
+
+pub fn build_match_arm_toks(
+    variants_with_message: Vec<(&syn::Variant, Message)>,
+    enum_name: &syn::Ident,
+) -> SubAttrToks {
+    let mut arms = HashMap::from([("content", vec![]), ("code", vec![]), ("exit_code", vec![])]);
+
+    for (variant, message) in variants_with_message {
+        let variant_name = &variant.ident;
+
+        let content = message.content;
+        let code = message.code;
+        let exit_code = message.exit_code;
+
+        // creates a pattern for varients with fields like
+        // Success(String, String) -> Success(_0, _1)
+        let fields_pat = match &variant.fields {
+            Fields::Unnamed(field) => {
+                let vars = field
+                    .unnamed
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| format_ident!("_{}", i));
+                Some(quote!((#(#vars),*)))
+            }
+            _ => None,
+        };
+
+        let lhs = match &fields_pat {
+            Some(fields_pat) => quote! {
+                #enum_name::#variant_name #fields_pat
+            },
+            None => quote! {
+                #enum_name::#variant_name
+            },
+        };
+
+        let content_rhs = match &fields_pat {
+            Some(fields_pat) => quote! {
+                format!(#content, #fields_pat)
+            },
+            None => quote! {
+                #content.to_string()
+            },
+        };
+
+        arms.entry("content").and_modify(|v| {
+            v.push(quote! {
+                #lhs => #content_rhs
+            })
+        });
+
+        arms.entry("code").and_modify(|v| {
+            v.push(quote! {
+                #lhs => #code.to_string()
+            })
+        });
+
+        arms.entry("exit_code").and_modify(|v| {
+            v.push(quote! {
+                #lhs => #exit_code
+            })
+        });
+    }
+
+    (
+        arms.get("content").expect("infallible").to_vec(),
+        arms.get("code").expect("infallible").to_vec(),
+        arms.get("exit_code").expect("infallible").to_vec(),
+    )
+}


### PR DESCRIPTION
# Why
Implements automatic derivation of the CliMessage trait for an enum

This lets us separate view logic easily by having any command (or helper) functions take the signature:
```rust
fn my_command(...) -> impl CliMessage {
```
and then create message enums for them.

 Supports magic derive for message codes, so an enum variant `RelayCreate::Success`will derive a message code of `relay-create-success`.

example:
 ```rust
 #[derive(CliMessage)]
 pub enum RelayCreate {
    #[message("Relay created successfully")]
    Success,
    #[message("A relay with the domain {} already exists")]
    AlreadyExists(String),
    #[message("Docker service isn't running", exit_code = 70)]
    DockerNotRunning,
    #[message("Domain name is too long", code = "too-long")]
    TooLong
 }
 ```

# How
write a macro.. fairly clear and well tested + shouldn't need to change very often

