### PR TITLE
Use encrypt API for enclave env secrets

### DIFF
--- a/crates/ev-cli/src/commands/decrypt.rs
+++ b/crates/ev-cli/src/commands/decrypt.rs
@@ -42,7 +42,7 @@ impl CmdOutput for DecryptError {
 
 #[derive(strum_macros::Display)]
 pub enum DecryptMessage {
-    #[strum(to_string = "{value}")]
+    #[strum(to_string = "Successfully decrypted data")]
     Success { value: Value },
 }
 
@@ -67,7 +67,7 @@ impl CmdOutput for DecryptMessage {
 
 pub async fn run(args: DecryptArgs, auth: BasicAuth) -> Result<DecryptMessage, DecryptError> {
     let api_client = EvApiClient::new(auth);
-    let decrypted = api_client.decrypt(Value::from_str(&args.data)?).await?;
+    let decrypted = api_client.decrypt(serde_json::json!(&args.data)).await?;
 
     Ok(DecryptMessage::Success { value: decrypted })
 }

--- a/crates/ev-cli/src/commands/enclave/env.rs
+++ b/crates/ev-cli/src/commands/enclave/env.rs
@@ -37,7 +37,7 @@ pub struct AddEnvArgs {
     #[clap(long = "value")]
     pub value: String,
 
-    /// Is the env var is a secret, it will be encrypted
+    /// If the env var is a secret, it will be encrypted
     #[clap(long = "secret")]
     pub is_secret: bool,
 

--- a/crates/ev-cli/src/commands/enclave/env.rs
+++ b/crates/ev-cli/src/commands/enclave/env.rs
@@ -15,17 +15,14 @@ pub struct EnvArgs {
 #[derive(Debug, Subcommand)]
 pub enum EnvCommands {
     #[command()]
-    /// Add Enclave environment variable
     Add(AddEnvArgs),
-    /// Delete Enclave environment variable
     #[command()]
     Delete(DeleteEnvArgs),
-    /// Get Enclave environment variables
     #[command()]
     Get(GetEnvArgs),
 }
 
-/// Add secret to Enclave env
+/// Add Enclave environment variable
 #[derive(Debug, Parser)]
 #[clap(name = "env", about)]
 pub struct AddEnvArgs {
@@ -46,7 +43,7 @@ pub struct AddEnvArgs {
     pub config: String,
 }
 
-/// Add delete secret from Enclave env
+/// Delete Enclave environment variable
 #[derive(Debug, Parser)]
 #[clap(name = "env", about)]
 pub struct DeleteEnvArgs {
@@ -59,7 +56,7 @@ pub struct DeleteEnvArgs {
     pub config: String,
 }
 
-/// Get secrets from Enclave env
+/// Get Enclave environment variables
 #[derive(Debug, Parser)]
 #[clap(name = "env", about)]
 pub struct GetEnvArgs {

--- a/crates/ev-cli/src/commands/enclave/env.rs
+++ b/crates/ev-cli/src/commands/enclave/env.rs
@@ -1,0 +1,109 @@
+use clap::{Parser, Subcommand};
+
+use common::api::{papi::EvApiClient, AuthMode};
+
+use ev_enclave::{api::enclave::EnclaveClient, env};
+
+/// Manage Enclave environment
+#[derive(Debug, Parser)]
+#[command(name = "cert", about)]
+pub struct EnvArgs {
+    #[command(subcommand)]
+    action: EnvCommands,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum EnvCommands {
+    #[command()]
+    /// Add Enclave environment variable
+    Add(AddEnvArgs),
+    /// Delete Enclave environment variable
+    #[command()]
+    Delete(DeleteEnvArgs),
+    /// Get Enclave environment variables
+    #[command()]
+    Get(GetEnvArgs),
+}
+
+/// Add secret to Enclave env
+#[derive(Debug, Parser)]
+#[clap(name = "env", about)]
+pub struct AddEnvArgs {
+    /// Name of environment variable
+    #[clap(long = "key")]
+    pub name: String,
+
+    /// Environment variable value
+    #[clap(long = "value")]
+    pub value: String,
+
+    /// Is the env var is a secret, it will be encrypted
+    #[clap(long = "secret")]
+    pub is_secret: bool,
+
+    /// Path to enclave.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
+    pub config: String,
+}
+
+/// Add delete secret from Enclave env
+#[derive(Debug, Parser)]
+#[clap(name = "env", about)]
+pub struct DeleteEnvArgs {
+    /// Name of environment variable
+    #[clap(long = "key")]
+    pub name: String,
+
+    /// Path to enclave.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
+    pub config: String,
+}
+
+/// Get secrets from Enclave env
+#[derive(Debug, Parser)]
+#[clap(name = "env", about)]
+pub struct GetEnvArgs {
+    /// Path to enclave.toml config file
+    #[clap(short = 'c', long = "config", default_value = "./enclave.toml")]
+    pub config: String,
+}
+
+pub async fn run(env_args: EnvArgs, app_uuid: String, api_key: String) -> exitcode::ExitCode {
+    let api_client = EvApiClient::new((app_uuid, api_key.clone()));
+    let enclave_api = EnclaveClient::new(AuthMode::ApiKey(api_key));
+
+    let result = match env_args.action {
+        EnvCommands::Add(add_args) => {
+            env::add_env_var(
+                enclave_api,
+                api_client,
+                add_args.config,
+                add_args.name,
+                add_args.value,
+                add_args.is_secret,
+            )
+            .await
+        }
+        EnvCommands::Delete(delete_args) => {
+            env::delete_env_var(enclave_api, delete_args.config, delete_args.name).await
+        }
+        EnvCommands::Get(get_args) => env::get_env_vars(enclave_api, get_args.config).await,
+    };
+
+    match result {
+        Ok(None) => {
+            log::info!("Environment updated successfully");
+            exitcode::OK
+        }
+        Ok(Some(env)) => {
+            let success_msg = serde_json::json!(env);
+            println!("{}", serde_json::to_string_pretty(&success_msg).unwrap());
+
+            exitcode::OK
+        }
+        Err(err) => {
+            log::error!("Error updating environment {err}");
+            exitcode::SOFTWARE
+        }
+    }
+}

--- a/crates/ev-cli/src/commands/enclave/mod.rs
+++ b/crates/ev-cli/src/commands/enclave/mod.rs
@@ -6,6 +6,7 @@ pub mod cert;
 pub mod delete;
 pub mod deploy;
 pub mod describe;
+pub mod env;
 pub mod init;
 pub mod list;
 pub mod logs;
@@ -41,6 +42,7 @@ pub enum AuthenticatedEnclaveCommand {
     Logs(logs::LogArgs),
     Restart(restart::RestartArgs),
     Scale(scale::ScaleArgs),
+    Env(env::EnvArgs),
 }
 
 pub async fn run(enclave_args: EnclaveArgs) {
@@ -51,7 +53,7 @@ pub async fn run(enclave_args: EnclaveArgs) {
         #[cfg(not(target_os = "windows"))]
         EnclaveCommand::Attest(attest_args) => attest::run(attest_args).await,
         EnclaveCommand::Authenticated(authenticated_command) => {
-            let (api_key, _) = crate::get_auth();
+            let (app_uuid, api_key) = crate::get_auth();
 
             match authenticated_command {
                 AuthenticatedEnclaveCommand::Cert(cert_args) => cert::run(cert_args, api_key).await,
@@ -69,6 +71,9 @@ pub async fn run(enclave_args: EnclaveArgs) {
                 }
                 AuthenticatedEnclaveCommand::Scale(scale_args) => {
                     scale::run(scale_args, api_key).await
+                }
+                AuthenticatedEnclaveCommand::Env(env_args) => {
+                    env::run(env_args, app_uuid, api_key).await
                 }
             }
         }

--- a/crates/ev-enclave/src/env/mod.rs
+++ b/crates/ev-enclave/src/env/mod.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 pub enum EnvError {
     #[error("An error occurred contacting the API — {0}")]
     ApiError(#[from] ApiError),
-    #[error("App and team uuid need to be provided in enclave.toml or as args")]
+    #[error("App, team and cage uuid need to be provided in enclave.toml or as args")]
     MissingAppInfo,
     #[error("An error occured during encryption — {0}")]
     EncryptError(ApiError),
@@ -78,16 +78,13 @@ pub struct EnclaveInfo {
 fn get_enclave_details(config_path: String) -> Result<EnclaveInfo, EnvError> {
     let enclave_config = EnclaveConfig::try_from_filepath(&config_path)?;
 
-    if enclave_config.app_uuid.is_none()
-        || enclave_config.team_uuid.is_none()
-        || enclave_config.uuid.is_none()
-    {
-        Err(EnvError::MissingAppInfo)
-    } else {
-        Ok(EnclaveInfo {
-            app_uuid: enclave_config.app_uuid.unwrap(),
-            team_uuid: enclave_config.team_uuid.unwrap(),
-            uuid: enclave_config.uuid.unwrap(),
-        })
-    }
+    let app_uuid = enclave_config.app_uuid.ok_or(EnvError::MissingAppInfo)?;
+    let team_uuid = enclave_config.team_uuid.ok_or(EnvError::MissingAppInfo)?;
+    let uuid = enclave_config.uuid.ok_or(EnvError::MissingAppInfo)?;
+
+    Ok(EnclaveInfo {
+        app_uuid,
+        team_uuid,
+        uuid,
+    })
 }

--- a/crates/ev-enclave/src/env/mod.rs
+++ b/crates/ev-enclave/src/env/mod.rs
@@ -1,0 +1,95 @@
+use crate::api::enclave::{AddSecretRequest, EnclaveApi, EnclaveClient, EnclaveEnv};
+use crate::config::{EnclaveConfig, EnclaveConfigError};
+use common::api::client::ApiError;
+use common::api::papi::{EvApi, EvApiClient};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum EnvError {
+    #[error("An error occurred contacting the API — {0}")]
+    ApiError(#[from] ApiError),
+    #[error("Error decoding public key — {0}")]
+    Base64DecodeError(#[from] base64::DecodeError),
+    #[error("App and team uuid need to be provided in enclave.toml or as args")]
+    MissingAppInfo,
+    #[error("An error occured during encryption — {0}")]
+    EncryptError(ApiError),
+    #[error("An error occured reading enclave.toml — {0}")]
+    EnclaveConfigError(#[from] EnclaveConfigError),
+}
+
+pub async fn add_env_var(
+    client: EnclaveClient,
+    papi_client: EvApiClient,
+    config_path: String,
+    key: String,
+    value: String,
+    is_secret: bool,
+) -> Result<Option<EnclaveEnv>, EnvError> {
+    let details = get_enclave_details(config_path)?;
+
+    let env_value = if is_secret {
+        papi_client
+            .encrypt(value.into())
+            .await
+            .map_err(EnvError::EncryptError)?
+            .to_string()
+    } else {
+        value
+    };
+
+    client
+        .add_env_var(
+            details.uuid,
+            AddSecretRequest {
+                name: key,
+                secret: env_value,
+            },
+        )
+        .await?;
+    Ok(None)
+}
+
+pub async fn delete_env_var(
+    client: EnclaveClient,
+    config_path: String,
+    key: String,
+) -> Result<Option<EnclaveEnv>, EnvError> {
+    let details = get_enclave_details(config_path)?;
+
+    client.delete_env_var(details.uuid, key).await?;
+
+    Ok(None)
+}
+
+pub async fn get_env_vars(
+    client: EnclaveClient,
+    config_path: String,
+) -> Result<Option<EnclaveEnv>, EnvError> {
+    let details = get_enclave_details(config_path)?;
+
+    Ok(Some(client.get_enclave_env(details.uuid).await?))
+}
+
+pub struct EnclaveInfo {
+    pub uuid: String,
+    pub team_uuid: String,
+    pub app_uuid: String,
+}
+
+fn get_enclave_details(config_path: String) -> Result<EnclaveInfo, EnvError> {
+    let enclave_config = EnclaveConfig::try_from_filepath(&config_path)?;
+
+    if enclave_config.app_uuid.is_none()
+        || enclave_config.team_uuid.is_none()
+        || enclave_config.uuid.is_none()
+    {
+        Err(EnvError::MissingAppInfo)
+    } else {
+        Ok(EnclaveInfo {
+            app_uuid: enclave_config.app_uuid.unwrap(),
+            team_uuid: enclave_config.team_uuid.unwrap(),
+            uuid: enclave_config.uuid.unwrap(),
+        })
+    }
+}

--- a/crates/ev-enclave/src/env/mod.rs
+++ b/crates/ev-enclave/src/env/mod.rs
@@ -8,8 +8,6 @@ use thiserror::Error;
 pub enum EnvError {
     #[error("An error occurred contacting the API — {0}")]
     ApiError(#[from] ApiError),
-    #[error("Error decoding public key — {0}")]
-    Base64DecodeError(#[from] base64::DecodeError),
     #[error("App and team uuid need to be provided in enclave.toml or as args")]
     MissingAppInfo,
     #[error("An error occured during encryption — {0}")]

--- a/crates/ev-enclave/src/lib.rs
+++ b/crates/ev-enclave/src/lib.rs
@@ -10,6 +10,7 @@ pub mod deploy;
 pub mod describe;
 pub mod docker;
 pub mod enclave;
+pub mod env;
 pub mod logs;
 pub mod migrate;
 pub mod progress;


### PR DESCRIPTION
# Why
After removing our internal rust crypto dependency, we removed this command from the codebase.

# How
Use the encrypt API to encrypt secret env vars.


