### PR TITLE
Remove quiet flag in favour of verbose

### DIFF
--- a/crates/ev-cli/src/commands/enclave/build.rs
+++ b/crates/ev-cli/src/commands/enclave/build.rs
@@ -6,6 +6,8 @@ use ev_enclave::config::{read_and_validate_config, BuildTimeConfig};
 use ev_enclave::docker::command::get_source_date_epoch;
 use ev_enclave::version::get_runtime_and_installer_version;
 
+use crate::BaseArgs;
+
 /// Build an Enclave from a Dockerfile
 #[derive(Parser, Debug)]
 #[command(name = "build", about)]
@@ -29,15 +31,6 @@ pub struct BuildArgs {
     /// Private key used to sign the Enclave image file
     #[arg(long = "private-key")]
     pub private_key: Option<String>,
-
-    /// Disable verbose logging
-    #[arg(long)]
-    pub quiet: bool,
-
-    // TODO(Mark): check
-    /// Enable JSON output
-    // #[arg(long, from_global)]
-    // pub json: bool,
 
     /// Path to directory where the processed dockerfile and Enclave will be saved
     #[arg(short = 'o', long = "output", default_value = ".")]
@@ -79,6 +72,8 @@ impl BuildTimeConfig for BuildArgs {
 }
 
 pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
+    let base_args = BaseArgs::parse();
+
     let (mut enclave_config, validated_config) =
         match read_and_validate_config(&build_args.config, &build_args) {
             Ok(config) => config,
@@ -111,7 +106,7 @@ pub async fn run(build_args: BuildArgs) -> exitcode::ExitCode {
         &validated_config,
         &build_args.context_path,
         Some(&build_args.output_dir),
-        !build_args.quiet,
+        base_args.verbose,
         borrowed_args,
         data_plane_version,
         installer_version,

--- a/crates/ev-cli/src/commands/enclave/delete.rs
+++ b/crates/ev-cli/src/commands/enclave/delete.rs
@@ -14,10 +14,6 @@ pub struct DeleteArgs {
     #[arg(long = "enclave-uuid")]
     pub enclave_uuid: Option<String>,
 
-    /// Disable verbose output
-    #[arg(long)]
-    pub quiet: bool,
-
     /// Perform the Enclave deletion in the background
     #[arg(long)]
     pub background: bool,

--- a/crates/ev-cli/src/commands/enclave/deploy.rs
+++ b/crates/ev-cli/src/commands/enclave/deploy.rs
@@ -16,6 +16,8 @@ use ev_enclave::{
 };
 use exitcode::ExitCode;
 
+use crate::BaseArgs;
+
 /// Deploy an Enclave from a toml file.
 #[derive(Debug, Parser)]
 #[command(name = "deploy", about)]
@@ -43,10 +45,6 @@ pub struct DeployArgs {
     /// Private key used to sign the Enclave image file
     #[arg(long = "private-key")]
     pub private_key: Option<String>,
-
-    /// Disable verbose output
-    #[arg(long)]
-    pub quiet: bool,
 
     /// Build time arguments to provide to docker
     #[arg(long = "build-arg")]
@@ -84,6 +82,7 @@ impl BuildTimeConfig for DeployArgs {
 }
 
 pub async fn run(deploy_args: DeployArgs, api_key: String) -> exitcode::ExitCode {
+    let base_args = BaseArgs::parse();
     let (mut enclave_config, validated_config) =
         match read_and_validate_config(&deploy_args.config, &deploy_args) {
             Ok(configs) => configs,
@@ -165,7 +164,7 @@ pub async fn run(deploy_args: DeployArgs, api_key: String) -> exitcode::ExitCode
         &validated_config,
         &deploy_args.context_path,
         deploy_args.eif_path.as_deref(),
-        !deploy_args.quiet,
+        base_args.verbose,
         build_args,
         from_existing,
         timestamp,

--- a/crates/ev-cli/src/commands/enclave/describe.rs
+++ b/crates/ev-cli/src/commands/enclave/describe.rs
@@ -2,6 +2,8 @@ use clap::Parser;
 use common::CliError;
 use ev_enclave::describe::describe_eif;
 
+use crate::BaseArgs;
+
 /// Get the PCRs of a built EIF
 #[derive(Debug, Parser)]
 #[command(name = "describe", about)]
@@ -10,19 +12,17 @@ pub struct DescribeArgs {
     #[arg(default_value = "./enclave.eif")]
     pub eif_path: String,
 
-    /// Disable verbose logging
-    #[arg(long)]
-    pub quiet: bool,
-
     /// Disables the use of cache during the image builds
     #[arg(long = "no-cache")]
     pub no_cache: bool,
 }
 
 pub async fn run(describe_args: DescribeArgs) -> exitcode::ExitCode {
+    let base_args = BaseArgs::parse();
+
     let description = match describe_eif(
         &describe_args.eif_path,
-        !describe_args.quiet,
+        base_args.verbose,
         describe_args.no_cache,
     ) {
         Ok(measurements) => measurements,


### PR DESCRIPTION
# Why
We've always had a global `--verbose` flag but some of the enclave commands have a `--quiet` flag too 

# How
~Only issue with this is we're changing the default output of these enclave commands from !quiet to verbose=true by default. ie by default there will be less logs~

Tested running the enclave commands without verbose logging by default and seems reasonable. Really just avoiding the docker build spam, there is still an appropriate level of logging
