### PR TITLE
Wrap strings to encrypt in quotes before encryption

### DIFF
--- a/crates/ev-cli/src/commands/encrypt.rs
+++ b/crates/ev-cli/src/commands/encrypt.rs
@@ -2,7 +2,7 @@ use crate::{errors, CmdOutput};
 use clap::Parser;
 use common::api::{client::ApiError, papi::EvApiClient};
 use common::api::{papi::EvApi, BasicAuth};
-use serde_json::{from_str, Value};
+use serde_json::Value;
 use std::str::FromStr;
 use thiserror::Error;
 

--- a/crates/ev-cli/src/commands/encrypt.rs
+++ b/crates/ev-cli/src/commands/encrypt.rs
@@ -71,7 +71,7 @@ pub async fn run(args: EncryptArgs, auth: BasicAuth) -> Result<EncryptMessage, E
 
     let data = match Value::from_str(&args.data) {
         Ok(val) => val,
-        Err(_) => format!("\"{}\"", args.data).parse::<Value>()?,
+        Err(_) => Value::String(args.data),
     };
 
     let encrypted = api_client.encrypt(data).await?;


### PR DESCRIPTION
# Why
Try wrap input in quotes if serialization fails. Plain strings are valid JSON but they must be wrapped in double quotes.

# How
Do it for the user so it's less confusing
