### PR TITLE
Correctly version minor for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "ev-cli"
-version = "4.2.0"
+version = "4.1.0"
 dependencies = [
  "async-trait",
  "attestation-doc-validation",

--- a/crates/ev-cli/Cargo.toml
+++ b/crates/ev-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "ev-cli"
-version = "4.2.0"
+version = "4.1.0"
 
 [[bin]]
 name = "ev"


### PR DESCRIPTION
# Why
Last ev cli release is 4.0.8 so this should be 4.1.0
# How
update Cargo.toml
