### PR TITLE
Correct parsing of docker env directives

### DIFF
--- a/crates/ev-enclave/src/docker/parse.rs
+++ b/crates/ev-enclave/src/docker/parse.rs
@@ -44,14 +44,14 @@ impl From<u8> for Mode {
 pub struct EnvVar {
     pub key: String,
     pub val: String,
-    pub delim: Delimiter
+    pub delim: Delimiter,
 }
 
 impl Display for EnvVar {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.delim {
-          Delimiter::Eq => write!(f, "{}={}", self.key, self.val)?,
-          Delimiter::None => write!(f, "{} {}", self.key, self.val)?,
+            Delimiter::Eq => write!(f, "{}={}", self.key, self.val)?,
+            Delimiter::None => write!(f, "{} {}", self.key, self.val)?,
         };
         Ok(())
     }
@@ -196,7 +196,7 @@ impl Directive {
             return Ok(vec![EnvVar {
                 key: key[0].to_string(),
                 val: values.join(" "),
-                delim
+                delim,
             }]);
         }
 
@@ -214,7 +214,11 @@ impl Directive {
                 .next()
                 .ok_or(DecodeError::IncompleteInstruction)?
                 .to_string();
-            env_vars.push(EnvVar { key, val, delim: delim.clone() });
+            env_vars.push(EnvVar {
+                key,
+                val,
+                delim: delim.clone(),
+            });
             i += 1;
         }
         return Ok(env_vars);
@@ -1196,7 +1200,7 @@ ENTRYPOINT apk update && apk add python3 glib make g++ gcc libc-dev &&\
         let env_directive = Directive::new_env(vec![EnvVar {
             key: "Hello".to_string(),
             val: "World".to_string(),
-            delim: Delimiter::Eq
+            delim: Delimiter::Eq,
         }]);
 
         assert_eq!(env_directive.is_env(), true);
@@ -1208,7 +1212,7 @@ ENTRYPOINT apk update && apk add python3 glib make g++ gcc libc-dev &&\
         let env_directive = Directive::new_env(vec![EnvVar {
             key: "Hello".to_string(),
             val: "World".to_string(),
-            delim: Delimiter::None
+            delim: Delimiter::None,
         }]);
 
         assert_eq!(env_directive.is_env(), true);
@@ -1221,12 +1225,12 @@ ENTRYPOINT apk update && apk add python3 glib make g++ gcc libc-dev &&\
             EnvVar {
                 key: "Hello".to_string(),
                 val: "World".to_string(),
-                delim: Delimiter::Eq
+                delim: Delimiter::Eq,
             },
             EnvVar {
                 key: "World".to_string(),
                 val: "Hello".to_string(),
-                delim: Delimiter::Eq
+                delim: Delimiter::Eq,
             },
         ]);
 


### PR DESCRIPTION
# Why

Docker env directives currently fail to parse when there is an uneven number of equals signs. 

# How

Update parsing logic to detect the delimiter and build up tokens more explicitly, before mapping down to key value pairs. Add improved test cases
