### PR TITLE
Update action secret to use Enclave CLI distribution

### DIFF
--- a/.github/workflows/release-cli-version.yml
+++ b/.github/workflows/release-cli-version.yml
@@ -51,7 +51,7 @@ jobs:
     secrets:
       aws-access-key-id: ${{ secrets.PUBLIC_REPO_AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY }}
-      aws-cloudfront-distribution-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+      aws-cloudfront-distribution-id: ${{ secrets.ENCLAVES_CLI_CLOUDFRONT_DISTRIBUTION_ID }}
       evervault-rust-lib-index: ${{ secrets.RUST_CRYPTO_REGISTRY }}
       evervault-rust-lib-token: ${{ secrets.CARGO_REGISTRIES_EVERVAULT_RUST_LIBRARIES_TOKEN }}
 


### PR DESCRIPTION
# Why

In consolidating the CLI, we began publishing behind a different CDN. The previous major releases need to be able to release to the original CDN to support patch releases.

# How

Add `ENCLAVES_CLI_CLOUDFRONT_DISTRIBUTION_ID` to the release workflow on v1 major branch
