### PR TITLE
Move enclave assets client out of common

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,2 @@
-[env]
-ENCLAVE_RUNTIME_VERSION = "1.0.5"
 [registry]
 global-credential-providers = ["cargo:token"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "ev-enclave"
-version = "1.0.0-dev"
+version = "1.0.5"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/crates/common/src/api/mod.rs
+++ b/crates/common/src/api/mod.rs
@@ -1,6 +1,5 @@
 pub mod assets;
 pub mod client;
-pub mod enclave_assets;
 pub mod function;
 pub mod papi;
 pub use reqwest::Client;

--- a/crates/common/src/enclave/mod.rs
+++ b/crates/common/src/enclave/mod.rs
@@ -1,13 +1,1 @@
 pub mod types;
-
-pub fn get_runtime_version() -> String {
-    env!("ENCLAVE_RUNTIME_VERSION").to_string()
-}
-
-pub fn get_runtime_major_version() -> String {
-    env!("ENCLAVE_RUNTIME_VERSION")
-        .split('.')
-        .next()
-        .expect("infallible")
-        .to_string()
-}

--- a/crates/ev-cli/Cargo.toml
+++ b/crates/ev-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "ev-cli"
-version = "4.1.2"
+version = "1.0.0-dev"
 
 [[bin]]
 name = "ev"

--- a/crates/ev-cli/src/commands/enclave/deploy.rs
+++ b/crates/ev-cli/src/commands/enclave/deploy.rs
@@ -149,7 +149,13 @@ pub async fn run(deploy_args: DeployArgs, (_, api_key): BasicAuth) -> exitcode::
         .as_ref()
         .map(|args| args.iter().map(AsRef::as_ref).collect());
 
-    let enclave_runtime = EnclaveRuntime::new().await.unwrap();
+    let enclave_runtime = match EnclaveRuntime::new().await {
+        Ok(versions) => versions,
+        Err(e) => {
+            log::error!("Failed to get data plane and installer versions – {e}");
+            return e.exitcode();
+        }
+    };
 
     let from_existing = deploy_args.from_existing;
     let (eif_measurements, output_path) = match resolve_eif(

--- a/crates/ev-cli/src/commands/enclave/deploy.rs
+++ b/crates/ev-cli/src/commands/enclave/deploy.rs
@@ -1,9 +1,9 @@
 use atty::Stream;
 use clap::Parser;
-use common::api::enclave_assets::EnclaveAssetsClient;
 use common::api::AuthMode;
 use common::api::{client::ApiErrorKind, BasicAuth};
 use common::CliError;
+use ev_enclave::version::EnclaveRuntime;
 use ev_enclave::{
     api::enclave::EnclaveApi,
     build::build_enclave_image_file,
@@ -14,7 +14,6 @@ use ev_enclave::{
     docker::command::get_source_date_epoch,
     enclave::EIFMeasurements,
 };
-use exitcode::ExitCode;
 
 use crate::BaseArgs;
 
@@ -150,14 +149,7 @@ pub async fn run(deploy_args: DeployArgs, (_, api_key): BasicAuth) -> exitcode::
         .as_ref()
         .map(|args| args.iter().map(AsRef::as_ref).collect());
 
-    let (data_plane_version, installer_version) = match get_data_plane_and_installer_version().await
-    {
-        Ok(versions) => versions,
-        Err(e) => {
-            log::error!("Failed to get data plane and installer versions – {e}");
-            return e;
-        }
-    };
+    let enclave_runtime = EnclaveRuntime::new().await.unwrap();
 
     let from_existing = deploy_args.from_existing;
     let (eif_measurements, output_path) = match resolve_eif(
@@ -168,8 +160,7 @@ pub async fn run(deploy_args: DeployArgs, (_, api_key): BasicAuth) -> exitcode::
         build_args,
         from_existing,
         timestamp,
-        data_plane_version.clone(),
-        installer_version.clone(),
+        &enclave_runtime,
         deploy_args.reproducible,
         deploy_args.no_cache,
     )
@@ -197,8 +188,7 @@ pub async fn run(deploy_args: DeployArgs, (_, api_key): BasicAuth) -> exitcode::
         enclave_api,
         output_path,
         &eif_measurements,
-        data_plane_version,
-        installer_version,
+        &enclave_runtime,
     )
     .await
     {
@@ -231,8 +221,7 @@ async fn resolve_eif(
     build_args: Option<Vec<&str>>,
     from_existing: Option<String>,
     timestamp: String,
-    data_plane_version: String,
-    installer_version: String,
+    enclave_runtime: &EnclaveRuntime,
     reproducible: bool,
     no_cache: bool,
 ) -> Result<(EIFMeasurements, OutputPath), exitcode::ExitCode> {
@@ -279,8 +268,7 @@ async fn resolve_eif(
             None,
             verbose,
             build_args,
-            data_plane_version,
-            installer_version,
+            enclave_runtime,
             timestamp,
             from_existing,
             reproducible,
@@ -293,26 +281,4 @@ async fn resolve_eif(
         })?;
         Ok((built_enclave.measurements().to_owned(), output_path))
     }
-}
-
-async fn get_data_plane_and_installer_version() -> Result<(String, String), ExitCode> {
-    let enclave_build_assets_client = EnclaveAssetsClient::new();
-    let data_plane_version = match enclave_build_assets_client.get_data_plane_version().await {
-        Ok(version) => version,
-        Err(e) => {
-            log::error!("Failed to retrieve the latest data plane version - {e:?}");
-            return Err(e.exitcode());
-        }
-    };
-    let installer_version = match enclave_build_assets_client
-        .get_runtime_installer_version()
-        .await
-    {
-        Ok(version) => version,
-        Err(e) => {
-            log::error!("Failed to retrieve the latest installer version - {e:?}");
-            return Err(e.exitcode());
-        }
-    };
-    Ok((data_plane_version, installer_version))
 }

--- a/crates/ev-cli/src/main.rs
+++ b/crates/ev-cli/src/main.rs
@@ -87,7 +87,7 @@ where
 }
 
 #[derive(Debug, Parser)]
-#[clap(name = "Evervault Enclave CLI", version)]
+#[clap(name = "Evervault CLI", version)]
 pub struct BaseArgs {
     /// Toggle verbose output
     #[clap(short, long, global = true, default_value_t = false)]

--- a/crates/ev-enclave/Cargo.toml
+++ b/crates/ev-enclave/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ev-enclave"
-version = "1.0.0-dev"
+version = "1.0.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/ev-enclave/src/api/enclave.rs
+++ b/crates/ev-enclave/src/api/enclave.rs
@@ -33,10 +33,7 @@ impl ApiClient for EnclaveClient {
     }
 
     fn accept(&self) -> String {
-        format!(
-            "application/json;version={}",
-            env!("ENCLAVE_RUNTIME_VERSION")
-        )
+        format!("application/json;version={}", env!("CARGO_PKG_VERSION"))
     }
 }
 

--- a/crates/ev-enclave/src/api/enclave.rs
+++ b/crates/ev-enclave/src/api/enclave.rs
@@ -1,4 +1,5 @@
 use crate::config::ValidatedEnclaveBuildConfig;
+use crate::version::EnclaveRuntime;
 
 use common::api::client::{ApiClient, ApiClientError, ApiResult, GenericApiClient, HandleResponse};
 use common::api::AuthMode;
@@ -357,8 +358,7 @@ impl CreateEnclaveDeploymentIntentRequest {
         pcrs: &crate::enclave::PCRs,
         config: ValidatedEnclaveBuildConfig,
         eif_size_bytes: u64,
-        data_plane_version: String,
-        installer_version: String,
+        enclave_runtime: &EnclaveRuntime,
         git_timestamp: String,
         git_hash: String,
         desired_replicas: Option<u32>,
@@ -375,8 +375,8 @@ impl CreateEnclaveDeploymentIntentRequest {
             not_after: config.signing.not_after(),
             metadata: VersionMetadata {
                 git_hash,
-                installer_version,
-                data_plane_version,
+                installer_version: enclave_runtime.installer_version.clone(),
+                data_plane_version: enclave_runtime.data_plane_version.clone(),
                 git_timestamp,
             },
             healthcheck: config.healthcheck().map(String::from),

--- a/crates/ev-enclave/src/api/enclave_assets.rs
+++ b/crates/ev-enclave/src/api/enclave_assets.rs
@@ -43,7 +43,10 @@ impl ApiClient for EnclaveAssetsClient {
     }
 
     fn accept(&self) -> String {
-        format!("application/json;version={}", env!("CARGO_PKG_VERSION"))
+        format!(
+            "application/json;version={}",
+            env!("CARGO_PKG_VERSION_MAJOR")
+        )
     }
 }
 

--- a/crates/ev-enclave/src/api/enclave_assets.rs
+++ b/crates/ev-enclave/src/api/enclave_assets.rs
@@ -74,7 +74,7 @@ impl EnclaveAssetsClient {
     }
 
     pub async fn get_runtime_versions(&self) -> ApiResult<RuntimeMajorVersion> {
-        let enclave_version = env!("CARGO_PKG_VERSION");
+        let enclave_version = env!("CARGO_PKG_VERSION_MAJOR");
         let data_plane_version = format!("{}/runtime/versions", self.base_url());
         let result = self
             .get(&data_plane_version)

--- a/crates/ev-enclave/src/api/enclave_assets.rs
+++ b/crates/ev-enclave/src/api/enclave_assets.rs
@@ -1,5 +1,3 @@
-use common::enclave::get_runtime_major_version;
-
 use common::api::{
     client::{
         ApiClient, ApiClientError, ApiError, ApiErrorKind, ApiResult, GenericApiClient,
@@ -45,10 +43,7 @@ impl ApiClient for EnclaveAssetsClient {
     }
 
     fn accept(&self) -> String {
-        format!(
-            "application/json;version={}",
-            env!("ENCLAVE_RUNTIME_VERSION")
-        )
+        format!("application/json;version={}", env!("CARGO_PKG_VERSION"))
     }
 }
 
@@ -79,7 +74,7 @@ impl EnclaveAssetsClient {
     }
 
     pub async fn get_runtime_versions(&self) -> ApiResult<RuntimeMajorVersion> {
-        let target_enclave_runtime = get_runtime_major_version();
+        let enclave_version = env!("CARGO_PKG_VERSION");
         let data_plane_version = format!("{}/runtime/versions", self.base_url());
         let result = self
             .get(&data_plane_version)
@@ -87,7 +82,7 @@ impl EnclaveAssetsClient {
             .await
             .handle_json_response::<RuntimeVersion>()
             .await?;
-        match result.versions.get(&target_enclave_runtime) {
+        match result.versions.get(enclave_version) {
             Some(versions) => Ok(versions.clone()),
             None => Err(ApiError::new(ApiErrorKind::NotFound)),
         }

--- a/crates/ev-enclave/src/api/mod.rs
+++ b/crates/ev-enclave/src/api/mod.rs
@@ -1,3 +1,4 @@
 pub mod enclave;
+pub mod enclave_assets;
 
 pub use reqwest::Client;

--- a/crates/ev-enclave/src/deploy/mod.rs
+++ b/crates/ev-enclave/src/deploy/mod.rs
@@ -5,6 +5,7 @@ use crate::config::ValidatedEnclaveBuildConfig;
 use crate::describe::describe_eif;
 use crate::enclave::{EIFMeasurements, ENCLAVE_FILENAME};
 use crate::progress::{get_tracker, poll_fn_and_report_status, ProgressLogger, StatusReport};
+use crate::version::EnclaveRuntime;
 use std::io::Write;
 use std::sync::Arc;
 mod error;
@@ -27,8 +28,7 @@ pub async fn deploy_eif<T: EnclaveApi + Clone>(
     enclave_api: T,
     output_path: OutputPath,
     eif_measurements: &EIFMeasurements,
-    data_plane_version: String,
-    installer_version: String,
+    enclave_runtime: &EnclaveRuntime,
 ) -> Result<(), DeployError> {
     let progress_bar = get_tracker("Zipping Enclave...", None);
     create_zip_archive_for_eif(output_path.path())?;
@@ -45,8 +45,7 @@ pub async fn deploy_eif<T: EnclaveApi + Clone>(
         eif_measurements.pcrs(),
         validated_config.clone(),
         eif_size_bytes,
-        data_plane_version,
-        installer_version,
+        &enclave_runtime,
         get_source_date_epoch(),
         get_git_hash(),
         validated_config

--- a/crates/ev-enclave/src/test_utils.rs
+++ b/crates/ev-enclave/src/test_utils.rs
@@ -3,7 +3,6 @@ use crate::api::enclave::{
     EnclaveRegionalDeployment, EnclaveSigningCert, EnclaveState, EnclaveVersion,
     GetEnclaveDeploymentResponse, GetEnclaveResponse,
 };
-use crate::api::enclave_assets::EnclaveAssetsClient;
 use crate::build::build_enclave_image_file;
 use crate::build::error::BuildError;
 use crate::common::OutputPath;
@@ -24,7 +23,6 @@ pub async fn build_test_enclave(
     )
     .expect("Failed to gen cert in tests");
     let build_args = get_test_build_args();
-    let assets_client = EnclaveAssetsClient::new();
 
     let enclave_runtime = EnclaveRuntime::new().await.unwrap();
     let timestamp = "0".to_string();

--- a/crates/ev-enclave/src/test_utils.rs
+++ b/crates/ev-enclave/src/test_utils.rs
@@ -3,12 +3,13 @@ use crate::api::enclave::{
     EnclaveRegionalDeployment, EnclaveSigningCert, EnclaveState, EnclaveVersion,
     GetEnclaveDeploymentResponse, GetEnclaveResponse,
 };
+use crate::api::enclave_assets::EnclaveAssetsClient;
 use crate::build::build_enclave_image_file;
 use crate::build::error::BuildError;
 use crate::common::OutputPath;
 use crate::config::{read_and_validate_config, ValidatedEnclaveBuildConfig};
 use crate::enclave::BuiltEnclave;
-use common::api::enclave_assets::EnclaveAssetsClient;
+use crate::version::EnclaveRuntime;
 
 pub async fn build_test_enclave(
     output_dir: Option<&str>,
@@ -25,8 +26,7 @@ pub async fn build_test_enclave(
     let build_args = get_test_build_args();
     let assets_client = EnclaveAssetsClient::new();
 
-    let data_plane_version = assets_client.get_data_plane_version().await.unwrap();
-    let installer_version = assets_client.get_runtime_installer_version().await.unwrap();
+    let enclave_runtime = EnclaveRuntime::new().await.unwrap();
     let timestamp = "0".to_string();
 
     build_enclave_image_file(
@@ -35,8 +35,7 @@ pub async fn build_test_enclave(
         output_dir,
         false,
         None,
-        data_plane_version,
-        installer_version,
+        &enclave_runtime,
         timestamp,
         from_existing,
         reproducible,


### PR DESCRIPTION
# Why
part 1 of #141

Having enclave_assets in common is pointless and it's annoying for keeping the HTTP client versioned with the rest of enclaves stuff.

# How
* Move enclave_assets client into `ev-enclave`.
* Created a struct to pass the dataplane version and installer version around. We had two different implementations of `get_runtime_and_dataplane_version` which were both making 2x network requests instead of one, so seemed like a good idea to refactor.

as an aside some kind of context thing in the CLI would be really nice so we didn't have to drill stuff like this through the whole stack
