### PR TITLE
Add support for health check table in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "ev-cli"
-version = "4.1.2"
+version = "1.0.0-dev"
 dependencies = [
  "async-trait",
  "attestation-doc-validation",

--- a/crates/ev-cli/src/commands/enclave/init.rs
+++ b/crates/ev-cli/src/commands/enclave/init.rs
@@ -4,7 +4,8 @@ use common::{api::AuthMode, CliError};
 use ev_enclave::api::enclave::{Enclave, EnclaveApi};
 use ev_enclave::cert::{create_new_cert, DesiredLifetime, DistinguishedName};
 use ev_enclave::config::{
-    default_dockerfile, EgressSettings, EnclaveConfig, ScalingSettings, SigningInfo,
+    default_dockerfile, EgressSettings, EnclaveConfig, HealthcheckConfig, ScalingSettings,
+    SigningInfo,
 };
 
 /// Initialize an Enclave.toml in the current directory
@@ -81,6 +82,10 @@ pub struct InitArgs {
     #[arg(long = "healthcheck")]
     pub healthcheck: Option<String>,
 
+    /// The port to send healthcheck requests to. This is required if TLS termination is disabled.
+    #[arg(long = "healthcheck-port")]
+    pub healthcheck_port: Option<u16>,
+
     /// The desired number of instances for your Enclave to use. Default is 2.
     #[arg(long = "desired-replicas")]
     pub desired_replicas: Option<u32>,
@@ -95,6 +100,15 @@ impl std::convert::From<InitArgs> for EnclaveConfig {
                 cert: val.cert_path,
                 key: val.key_path,
             })
+        };
+
+        let healthcheck = if val.healthcheck.is_some() && val.healthcheck_port.is_some() {
+            Some(HealthcheckConfig::new_table(
+                val.healthcheck.as_ref().unwrap(),
+                val.healthcheck_port.unwrap(),
+            ))
+        } else {
+            val.healthcheck.map(HealthcheckConfig::from)
         };
 
         EnclaveConfig {
@@ -117,7 +131,7 @@ impl std::convert::From<InitArgs> for EnclaveConfig {
             trx_logging: !val.trx_logging_disabled,
             forward_proxy_protocol: val.forward_proxy_protocol,
             trusted_headers: convert_comma_list(val.trusted_headers).unwrap_or_default(),
-            healthcheck: val.healthcheck,
+            healthcheck,
         }
     }
 }
@@ -196,20 +210,9 @@ mod init_tests {
     use std::fs::read;
     use tempfile::TempDir;
 
-    #[tokio::test]
-    async fn init_local_config_test() {
-        let output_dir = TempDir::new().unwrap();
-        let sample_enclave = Enclave {
-            uuid: "1234".into(),
-            name: "hello-enclave".into(),
-            team_uuid: "1234".into(),
-            app_uuid: "1234".into(),
-            domain: "hello.com".into(),
-            state: EnclaveState::Pending,
-            created_at: "00:00:00".into(),
-            updated_at: "00:00:00".into(),
-        };
-        let init_args = InitArgs {
+    /// Helper which returns a minimal set of init args. Can be modified for specific tests.
+    fn default_init_args(output_dir: &TempDir) -> InitArgs {
+        InitArgs {
             output_dir: output_dir.path().to_str().unwrap().to_string(),
             enclave_name: "hello".to_string(),
             debug: false,
@@ -226,7 +229,24 @@ mod init_tests {
             forward_proxy_protocol: false,
             trusted_headers: Some("X-Evervault-*".to_string()),
             healthcheck: None,
+            healthcheck_port: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn init_local_config_test() {
+        let output_dir = TempDir::new().unwrap();
+        let sample_enclave = Enclave {
+            uuid: "1234".into(),
+            name: "hello-enclave".into(),
+            team_uuid: "1234".into(),
+            app_uuid: "1234".into(),
+            domain: "hello.com".into(),
+            state: EnclaveState::Pending,
+            created_at: "00:00:00".into(),
+            updated_at: "00:00:00".into(),
         };
+        let init_args = default_init_args(&output_dir);
         init_local_config(init_args, sample_enclave).await;
         let config_path = output_dir.path().join("enclave.toml");
         assert!(config_path.exists());
@@ -243,6 +263,104 @@ trx_logging = true
 tls_termination = true
 forward_proxy_protocol = false
 trusted_headers = ["X-Evervault-*"]
+
+[egress]
+enabled = true
+destinations = ["evervault.com"]
+
+[scaling]
+desired_replicas = 2
+
+[signing]
+certPath = "./cert.pem"
+keyPath = "./key.pem"
+"#;
+        assert_eq!(config_content, expected_config_content);
+    }
+
+    #[tokio::test]
+    async fn init_local_config_test_with_simple_healthcheck() {
+        let output_dir = TempDir::new().unwrap();
+        let sample_enclave = Enclave {
+            uuid: "1234".into(),
+            name: "hello-enclave".into(),
+            team_uuid: "1234".into(),
+            app_uuid: "1234".into(),
+            domain: "hello.com".into(),
+            state: EnclaveState::Pending,
+            created_at: "00:00:00".into(),
+            updated_at: "00:00:00".into(),
+        };
+        let mut init_args = default_init_args(&output_dir);
+        init_args.healthcheck = Some("/health".into());
+        init_local_config(init_args, sample_enclave).await;
+        let config_path = output_dir.path().join("enclave.toml");
+        assert!(config_path.exists());
+        let config_content = String::from_utf8(read(config_path).unwrap()).unwrap();
+        let expected_config_content = r#"version = 1
+name = "hello"
+uuid = "1234"
+app_uuid = "1234"
+team_uuid = "1234"
+debug = false
+dockerfile = "Dockerfile"
+api_key_auth = true
+trx_logging = true
+tls_termination = true
+forward_proxy_protocol = false
+trusted_headers = ["X-Evervault-*"]
+healthcheck = "/health"
+
+[egress]
+enabled = true
+destinations = ["evervault.com"]
+
+[scaling]
+desired_replicas = 2
+
+[signing]
+certPath = "./cert.pem"
+keyPath = "./key.pem"
+"#;
+        assert_eq!(config_content, expected_config_content);
+    }
+
+    #[tokio::test]
+    async fn init_local_config_test_with_custom_port_and_path_healthcheck() {
+        let output_dir = TempDir::new().unwrap();
+        let sample_enclave = Enclave {
+            uuid: "1234".into(),
+            name: "hello-enclave".into(),
+            team_uuid: "1234".into(),
+            app_uuid: "1234".into(),
+            domain: "hello.com".into(),
+            state: EnclaveState::Pending,
+            created_at: "00:00:00".into(),
+            updated_at: "00:00:00".into(),
+        };
+        let mut init_args = default_init_args(&output_dir);
+        init_args.healthcheck = Some("/health".into());
+        init_args.healthcheck_port = Some(8080);
+        init_local_config(init_args, sample_enclave).await;
+        let config_path = output_dir.path().join("enclave.toml");
+        assert!(config_path.exists());
+        let config_content = String::from_utf8(read(config_path).unwrap()).unwrap();
+        let expected_config_content = r#"version = 1
+name = "hello"
+uuid = "1234"
+app_uuid = "1234"
+team_uuid = "1234"
+debug = false
+dockerfile = "Dockerfile"
+api_key_auth = true
+trx_logging = true
+tls_termination = true
+forward_proxy_protocol = false
+trusted_headers = ["X-Evervault-*"]
+
+[healthcheck]
+path = "/health"
+port = 8080
 
 [egress]
 enabled = true

--- a/crates/ev-enclave/src/api/enclave.rs
+++ b/crates/ev-enclave/src/api/enclave.rs
@@ -345,6 +345,8 @@ pub struct CreateEnclaveDeploymentIntentRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     healthcheck: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    healthcheck_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     desired_replicas: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pcrs_signature: Option<String>,
@@ -376,7 +378,10 @@ impl CreateEnclaveDeploymentIntentRequest {
                 data_plane_version: enclave_runtime.data_plane_version.clone(),
                 git_timestamp,
             },
-            healthcheck: config.healthcheck().map(String::from),
+            healthcheck: config
+                .healthcheck()
+                .map(|hc_config| hc_config.path().into()),
+            healthcheck_port: config.healthcheck().and_then(|hc_config| hc_config.port()),
             desired_replicas,
             pcrs_signature,
         }

--- a/crates/ev-enclave/src/build/mod.rs
+++ b/crates/ev-enclave/src/build/mod.rs
@@ -293,6 +293,7 @@ async fn process_dockerfile<R: AsyncRead + std::marker::Unpin>(
             .port()
             .map(|port| Value::Number(Number::from(port)))
             .unwrap_or_else(|| Value::Null);
+        dataplane_info["healthcheck_use_tls"] = json!(build_config.use_tls_healthcheck());
     }
 
     let dataplane_env = format!(
@@ -766,10 +767,127 @@ USER root
 RUN mkdir -p /opt/evervault
 ADD https://enclave-build-assets.evervault.com/installer/abcdef.tar.gz /opt/evervault/runtime-dependencies.tar.gz
 RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
-RUN echo {\"api_key_auth\":true,\"forward_proxy_protocol\":false,\"healthcheck\":\"/health\",\"healthcheck_port\":null,\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
+RUN echo {\"api_key_auth\":true,\"forward_proxy_protocol\":false,\"healthcheck\":\"/health\",\"healthcheck_port\":null,\"healthcheck_use_tls\":false,\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
 RUN mkdir -p /etc/service/user-entrypoint
 RUN printf "#!/bin/sh\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
 ADD https://enclave-build-assets.evervault.com/runtime/0.0.0/data-plane/egress-disabled/tls-termination-enabled /opt/evervault/data-plane
+RUN chmod +x /opt/evervault/data-plane
+RUN mkdir -p /etc/service/data-plane
+RUN printf "#!/bin/sh\necho \"Booting Evervault data plane...\"\nexec /opt/evervault/data-plane 3443\n" > /etc/service/data-plane/run && chmod +x /etc/service/data-plane/run
+RUN printf "#!/bin/sh\nifconfig lo 127.0.0.1\n echo \"enclave.local\" > /etc/hostname \n echo \"127.0.0.1 enclave.local\" >> /etc/hosts \n hostname -F /etc/hostname \necho \"Booting enclave...\"\nexec runsvdir /etc/service\n" > /bootstrap && chmod +x /bootstrap
+ENTRYPOINT ["/bootstrap", "1>&2"]
+"##;
+
+        let expected_directives = docker::parse::DockerfileDecoder::decode_dockerfile_from_src(
+            expected_output_contents.as_bytes(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(expected_directives.len(), processed_file.len());
+        for (expected_directive, processed_directive) in
+            zip(expected_directives.iter(), processed_file.iter())
+        {
+            let expected_directive = expected_directive.to_string();
+            let processed_directive = processed_directive.to_string();
+            assert_eq!(expected_directive, processed_directive);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_dockerfile_with_tls_termination_disabled_and_path_only_healthcheck() {
+        let sample_dockerfile_contents = r#"FROM alpine
+
+RUN touch /hello-script;\
+    /bin/sh -c "echo -e '"'#!/bin/sh\nwhile true; do echo "hello"; sleep 2; done;\n'"' > /hello-script"
+EXPOSE 3443
+ENTRYPOINT ["sh", "/hello-script"]"#;
+        let mut readable_contents = sample_dockerfile_contents.as_bytes();
+
+        let mut config: ValidatedEnclaveBuildConfig = get_config(false);
+        config.tls_termination = false;
+        config.healthcheck = Some(crate::config::HealthcheckConfig::Path("/health".into()));
+
+        let enclave_runtime = EnclaveRuntime {
+            data_plane_version: "0.0.0".to_string(),
+            installer_version: "abcdef".to_string(),
+        };
+        let processed_file =
+            process_dockerfile(&config, &mut readable_contents, &enclave_runtime, false).await;
+        assert_eq!(processed_file.is_ok(), true);
+        let processed_file = processed_file.unwrap();
+
+        let expected_output_contents = r##"FROM alpine
+RUN touch /hello-script;\
+    /bin/sh -c "echo -e '"'#!/bin/sh\nwhile true; do echo "hello"; sleep 2; done;\n'"' > /hello-script"
+USER root
+RUN mkdir -p /opt/evervault
+ADD https://enclave-build-assets.evervault.com/installer/abcdef.tar.gz /opt/evervault/runtime-dependencies.tar.gz
+RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
+RUN echo {\"api_key_auth\":true,\"forward_proxy_protocol\":false,\"healthcheck\":\"/health\",\"healthcheck_port\":null,\"healthcheck_use_tls\":true,\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
+RUN mkdir -p /etc/service/user-entrypoint
+RUN printf "#!/bin/sh\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
+ADD https://enclave-build-assets.evervault.com/runtime/0.0.0/data-plane/egress-disabled/tls-termination-disabled /opt/evervault/data-plane
+RUN chmod +x /opt/evervault/data-plane
+RUN mkdir -p /etc/service/data-plane
+RUN printf "#!/bin/sh\necho \"Booting Evervault data plane...\"\nexec /opt/evervault/data-plane 3443\n" > /etc/service/data-plane/run && chmod +x /etc/service/data-plane/run
+RUN printf "#!/bin/sh\nifconfig lo 127.0.0.1\n echo \"enclave.local\" > /etc/hostname \n echo \"127.0.0.1 enclave.local\" >> /etc/hosts \n hostname -F /etc/hostname \necho \"Booting enclave...\"\nexec runsvdir /etc/service\n" > /bootstrap && chmod +x /bootstrap
+ENTRYPOINT ["/bootstrap", "1>&2"]
+"##;
+
+        let expected_directives = docker::parse::DockerfileDecoder::decode_dockerfile_from_src(
+            expected_output_contents.as_bytes(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(expected_directives.len(), processed_file.len());
+        for (expected_directive, processed_directive) in
+            zip(expected_directives.iter(), processed_file.iter())
+        {
+            let expected_directive = expected_directive.to_string();
+            let processed_directive = processed_directive.to_string();
+            assert_eq!(expected_directive, processed_directive);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_process_dockerfile_with_tls_termination_disabled_and_path_and_port_healthcheck() {
+        let sample_dockerfile_contents = r#"FROM alpine
+
+RUN touch /hello-script;\
+    /bin/sh -c "echo -e '"'#!/bin/sh\nwhile true; do echo "hello"; sleep 2; done;\n'"' > /hello-script"
+EXPOSE 3443
+ENTRYPOINT ["sh", "/hello-script"]"#;
+        let mut readable_contents = sample_dockerfile_contents.as_bytes();
+
+        let mut config: ValidatedEnclaveBuildConfig = get_config(false);
+        config.tls_termination = false;
+        config.healthcheck = Some(crate::config::HealthcheckConfig::Table {
+          port: Some(8080),
+          path: "/health".into()
+        });
+
+        let enclave_runtime = EnclaveRuntime {
+            data_plane_version: "0.0.0".to_string(),
+            installer_version: "abcdef".to_string(),
+        };
+        let processed_file =
+            process_dockerfile(&config, &mut readable_contents, &enclave_runtime, false).await;
+        assert_eq!(processed_file.is_ok(), true);
+        let processed_file = processed_file.unwrap();
+
+        let expected_output_contents = r##"FROM alpine
+RUN touch /hello-script;\
+    /bin/sh -c "echo -e '"'#!/bin/sh\nwhile true; do echo "hello"; sleep 2; done;\n'"' > /hello-script"
+USER root
+RUN mkdir -p /opt/evervault
+ADD https://enclave-build-assets.evervault.com/installer/abcdef.tar.gz /opt/evervault/runtime-dependencies.tar.gz
+RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
+RUN echo {\"api_key_auth\":true,\"forward_proxy_protocol\":false,\"healthcheck\":\"/health\",\"healthcheck_port\":8080,\"healthcheck_use_tls\":false,\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
+RUN mkdir -p /etc/service/user-entrypoint
+RUN printf "#!/bin/sh\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
+ADD https://enclave-build-assets.evervault.com/runtime/0.0.0/data-plane/egress-disabled/tls-termination-disabled /opt/evervault/data-plane
 RUN chmod +x /opt/evervault/data-plane
 RUN mkdir -p /etc/service/data-plane
 RUN printf "#!/bin/sh\necho \"Booting Evervault data plane...\"\nexec /opt/evervault/data-plane 3443\n" > /etc/service/data-plane/run && chmod +x /etc/service/data-plane/run

--- a/crates/ev-enclave/src/build/mod.rs
+++ b/crates/ev-enclave/src/build/mod.rs
@@ -864,8 +864,8 @@ ENTRYPOINT ["sh", "/hello-script"]"#;
         let mut config: ValidatedEnclaveBuildConfig = get_config(false);
         config.tls_termination = false;
         config.healthcheck = Some(crate::config::HealthcheckConfig::Table {
-          port: Some(8080),
-          path: "/health".into()
+            port: Some(8080),
+            path: "/health".into(),
         });
 
         let enclave_runtime = EnclaveRuntime {

--- a/crates/ev-enclave/src/build/mod.rs
+++ b/crates/ev-enclave/src/build/mod.rs
@@ -748,7 +748,7 @@ ENTRYPOINT ["sh", "/hello-script"]"#;
         let mut readable_contents = sample_dockerfile_contents.as_bytes();
 
         let mut config: ValidatedEnclaveBuildConfig = get_config(false);
-        config.healthcheck = Some("/health".into());
+        config.healthcheck = Some(crate::config::HealthcheckConfig::Path("/health".into()));
 
         let enclave_runtime = EnclaveRuntime {
             data_plane_version: "0.0.0".to_string(),
@@ -766,7 +766,7 @@ USER root
 RUN mkdir -p /opt/evervault
 ADD https://enclave-build-assets.evervault.com/installer/abcdef.tar.gz /opt/evervault/runtime-dependencies.tar.gz
 RUN cd /opt/evervault ; tar -xzf runtime-dependencies.tar.gz ; sh ./installer.sh ; rm runtime-dependencies.tar.gz
-RUN echo {\"api_key_auth\":true,\"forward_proxy_protocol\":false,\"healthcheck\":\"/health\",\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
+RUN echo {\"api_key_auth\":true,\"forward_proxy_protocol\":false,\"healthcheck\":\"/health\",\"healthcheck_port\":null,\"trusted_headers\":[\"X-Evervault-*\"],\"trx_logging_enabled\":true} > /etc/dataplane-config.json
 RUN mkdir -p /etc/service/user-entrypoint
 RUN printf "#!/bin/sh\nsleep 5\necho \"Checking status of data-plane\"\nSVDIR=/etc/service sv check data-plane || exit 1\necho \"Data-plane up and running\"\nwhile ! grep -q \"EV_INITIALIZED\" /etc/customer-env\n do echo \"Env not ready, sleeping user process for one second\"\n sleep 1\n done \n . /etc/customer-env\n\necho \"Booting user service...\"\ncd %s\nexec sh /hello-script\n" "$PWD"  > /etc/service/user-entrypoint/run && chmod +x /etc/service/user-entrypoint/run
 ADD https://enclave-build-assets.evervault.com/runtime/0.0.0/data-plane/egress-disabled/tls-termination-enabled /opt/evervault/data-plane

--- a/crates/ev-enclave/src/config.rs
+++ b/crates/ev-enclave/src/config.rs
@@ -436,6 +436,15 @@ impl ValidatedEnclaveBuildConfig {
     pub fn healthcheck(&self) -> Option<&HealthcheckConfig> {
         self.healthcheck.as_ref()
     }
+
+    /// TLS Healthchecks are not explicitly configurable. They are only enabled when a legacy healthcheck is defined (path only) for an Enclave with
+    /// TLS Termination disabled. This is here to avoid a breaking change in behaviour, but TLS healthchecks are not a recommended pattern. Users should define 
+    /// a dedicated port for their healthcheck requests instead.
+    pub fn use_tls_healthcheck(&self) -> bool {
+        self.healthcheck()
+            .map(|cfg| cfg.port().is_none() && !self.tls_termination)
+            .unwrap_or(false)
+    }
 }
 
 impl EnclaveConfig {

--- a/crates/ev-enclave/src/config.rs
+++ b/crates/ev-enclave/src/config.rs
@@ -220,7 +220,7 @@ pub fn default_true() -> bool {
     true
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum HealthcheckConfig {
     Path(String),
@@ -240,6 +240,19 @@ impl HealthcheckConfig {
             HealthcheckConfig::Path(_) => None,
             HealthcheckConfig::Table { port, .. } => port.as_ref().map(|port_num| *port_num),
         }
+    }
+
+    pub fn new_table<T: std::convert::Into<String>>(path: T, port: u16) -> Self {
+        Self::Table {
+            path: path.into(),
+            port: Some(port),
+        }
+    }
+}
+
+impl<T: std::convert::Into<String>> std::convert::From<T> for HealthcheckConfig {
+    fn from(value: T) -> Self {
+        Self::Path(value.into())
     }
 }
 
@@ -657,7 +670,9 @@ mod test {
             trx_logging: true,
             forward_proxy_protocol: false,
             trusted_headers: vec![],
-            healthcheck: Some("/health".to_string()),
+            healthcheck: Some(crate::config::HealthcheckConfig::Path(
+                "/health".to_string(),
+            )),
         };
 
         let test_args = ExampleArgs {
@@ -671,5 +686,52 @@ mod test {
         assert_eq!(merged.dockerfile(), test_args.dockerfile().unwrap());
         assert_eq!(merged.cert().unwrap(), test_args.certificate().unwrap());
         assert_eq!(merged.key().unwrap(), test_args.private_key().unwrap());
+    }
+
+    #[test]
+    fn merge_args_with_config_using_healthcheck_table() {
+        let config = EnclaveConfig {
+            version: 1,
+            name: "Enclave123".to_string(),
+            uuid: Some("abcdef123".to_string()),
+            app_uuid: Some("abcdef321".to_string()),
+            team_uuid: Some("team_abcdef456".to_string()),
+            debug: false,
+            dockerfile: "./Dockerfile.config".to_string(),
+            tls_termination: true,
+            egress: super::EgressSettings {
+                enabled: false,
+                destinations: None,
+            },
+            scaling: Some(super::ScalingSettings {
+                desired_replicas: 2,
+            }),
+            signing: None,
+            attestation: None,
+            api_key_auth: true,
+            trx_logging: true,
+            forward_proxy_protocol: false,
+            trusted_headers: vec![],
+            healthcheck: Some(crate::config::HealthcheckConfig::Table {
+                path: "/health".to_string(),
+                port: Some(8080),
+            }),
+        };
+
+        let test_args = ExampleArgs {
+            cert: "args-cert.pem".to_string(),
+            dockerfile: "./Dockerfile.args".to_string(),
+            pk: "pk.pem".to_string(),
+        };
+
+        let merged = test_args.merge_with_config(&config);
+        assert!(merged.signing.is_some());
+        assert_eq!(merged.dockerfile(), test_args.dockerfile().unwrap());
+        assert_eq!(merged.cert().unwrap(), test_args.certificate().unwrap());
+        assert_eq!(merged.key().unwrap(), test_args.private_key().unwrap());
+        assert_eq!(
+            merged.healthcheck.unwrap(),
+            config.healthcheck.clone().unwrap()
+        );
     }
 }

--- a/crates/ev-enclave/src/config.rs
+++ b/crates/ev-enclave/src/config.rs
@@ -438,7 +438,7 @@ impl ValidatedEnclaveBuildConfig {
     }
 
     /// TLS Healthchecks are not explicitly configurable. They are only enabled when a legacy healthcheck is defined (path only) for an Enclave with
-    /// TLS Termination disabled. This is here to avoid a breaking change in behaviour, but TLS healthchecks are not a recommended pattern. Users should define 
+    /// TLS Termination disabled. This is here to avoid a breaking change in behaviour, but TLS healthchecks are not a recommended pattern. Users should define
     /// a dedicated port for their healthcheck requests instead.
     pub fn use_tls_healthcheck(&self) -> bool {
         self.healthcheck()


### PR DESCRIPTION
# Why

There are several cases where an Enclave may need its Healthcheck to be handled on a dedicated port:
- Custom TLS termination. If the data plane is not terminating TLS, then we likely cannot perform a healthcheck against the process as the cert may be untrusted or require client auth.
- Removing healthchecks from public API. It may be preferable to remove the healthcheck from the public API of the Enclave, in which case it should be exposed on a dedicated port.

# How

- Add support in the config for path and port healthcheck configs. This change will respect both the new config and any existing path based config.
- Extend init args to provide a healthcheck port
- Update build to output the healthcheck port into the in enclave config file
- Update tests to assert port is respected in config