### PR TITLE
Add integrity check on CLI install

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,6 +1,6 @@
 name: 'Build and publish CLI'
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       stage:
         required: true
@@ -15,13 +15,13 @@ on:
       ev-domain:
         required: true
         type: string
-    # secrets:
-    #   aws-cloudfront-distribution-id:
-    #     required: true
-    #   aws-access-key-id:
-    #     required: true
-    #   aws-secret-access-key:
-    #     required: true
+    secrets:
+      aws-cloudfront-distribution-id:
+        required: true
+      aws-access-key-id:
+        required: true
+      aws-secret-access-key:
+        required: true
 env:
   RUST_BACKTRACE: 1
   MACOS_TARGET: x86_64-apple-darwin
@@ -111,12 +111,12 @@ jobs:
     needs: [compile-ubuntu, compile-macos]
     runs-on: ubuntu-latest
     steps:
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@v4
-      #   with:
-      #     aws-access-key-id: ${{ secrets.aws-access-key-id }}
-      #     aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
-      #     aws-region: us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-region: us-east-1
       - name: Download MacOS Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
@@ -132,24 +132,25 @@ jobs:
         run: |
           echo "macos_hash=$(cat macos/macos.hash)" >> $GITHUB_OUTPUT
           echo "linux_hash=$(cat linux/linux.hash)" >> $GITHUB_OUTPUT
-      # - name: Upload MacOS CLI to S3
-      #   run:
-      #     aws s3 cp ./macos/ev-${{ env.MACOS_TARGET }}-${{ inputs.full-version
-      #     }}.tar.gz s3://cli-assets-bucket-${{ inputs.stage }}/${{
-      #     inputs.major-version }}/${{ inputs.full-version }}/${{
-      #     env.MACOS_TARGET }}/ev.tar.gz
-      # - name: Upload Ubuntu CLI to S3
-      #   run:
-      #     aws s3 cp ./linux/ev-${{ env.LINUX_TARGET }}-${{ inputs.full-version
-      #     }}.tar.gz s3://cli-assets-bucket-${{ inputs.stage }}/${{
-      #     inputs.major-version }}/${{ inputs.full-version }}/${{
-      #     env.LINUX_TARGET }}/ev.tar.gz
+      - name: Upload MacOS CLI to S3
+        run:
+          aws s3 cp ./macos/ev-${{ env.MACOS_TARGET }}-${{ inputs.full-version
+          }}.tar.gz s3://cli-assets-bucket-${{ inputs.stage }}/${{
+          inputs.major-version }}/${{ inputs.full-version }}/${{
+          env.MACOS_TARGET }}/ev.tar.gz
+      - name: Upload Ubuntu CLI to S3
+        run:
+          aws s3 cp ./linux/ev-${{ env.LINUX_TARGET }}-${{ inputs.full-version
+          }}.tar.gz s3://cli-assets-bucket-${{ inputs.stage }}/${{
+          inputs.major-version }}/${{ inputs.full-version }}/${{
+          env.LINUX_TARGET }}/ev.tar.gz
       - uses: actions/checkout@v4
       - name: Update install script in S3
         working-directory: crates/ev-cli
         run: |
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }} ${{ steps.read-hashes.outputs.macos_hash }} ${{ steps.read-hashes.outputs.linux_hash }}
-          cat ./scripts/install
+          sh ./scripts/update-versions.sh ${{ inputs.full-version }} ${{ inputs.ev-domain }}
+          
           # Calculate hash of the install script
           INSTALL_SCRIPT_HASH=$(shasum -a 256 ./scripts/install | cut -d ' ' -f 1)
           echo "Install script hash: $INSTALL_SCRIPT_HASH"
@@ -159,5 +160,11 @@ jobs:
           echo "**SHA-256 Hash**: \`$INSTALL_SCRIPT_HASH\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version**: ${{ inputs.full-version }}" >> $GITHUB_STEP_SUMMARY
-          exit 0
+
+          aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/${{ inputs.full-version }}/install
+          aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/install
+          aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/version
+          aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/version
+          aws s3 cp scripts/versions s3://cli-assets-bucket-${{ inputs.stage }}/versions
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/v4/install" "/version" "/versions"
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -150,6 +150,13 @@ jobs:
         run: |
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }} ${{ steps.read-hashes.outputs.macos_hash }} ${{ steps.read-hashes.outputs.linux_hash }}
           cat ./scripts/install
-          sh ./scripts/install
+          # Calculate hash of the install script
+          INSTALL_SCRIPT_HASH=$(shasum -a 256 ./scripts/install | cut -d ' ' -f 1)
+          echo "Install script hash: $INSTALL_SCRIPT_HASH"
+          # Add hash to GitHub Actions summary
+          echo "### Install Script Hash" >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo "$INSTALL_SCRIPT_HASH" >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY
           exit 0
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -150,5 +150,6 @@ jobs:
         run: |
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }} ${{ steps.read-hashes.outputs.macos_hash }} ${{ steps.read-hashes.outputs.linux_hash }}
           cat ./scripts/install
+          sh ./scripts/install
           exit 0
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -155,8 +155,9 @@ jobs:
           echo "Install script hash: $INSTALL_SCRIPT_HASH"
           # Add hash to GitHub Actions summary
           echo "### Install Script Hash" >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
-          echo "$INSTALL_SCRIPT_HASH" >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**SHA-256 Hash**: \`$INSTALL_SCRIPT_HASH\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version**: ${{ inputs.full-version }}" >> $GITHUB_STEP_SUMMARY
           exit 0
 

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -150,4 +150,11 @@ jobs:
         run: |
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }} ${{ steps.read-hashes.outputs.macos_hash }} ${{ steps.read-hashes.outputs.linux_hash }}
           cat ./scripts/install
-          sh ./scripts/update-versions.sh ${{ inputs.full-version }} ${{ inputs.ev-domain }}
+          # sh ./scripts/update-versions.sh ${{ inputs.full-version }} ${{ inputs.ev-domain }}
+
+          # aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/${{ inputs.full-version }}/install
+          # aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/install
+          # aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/version
+          # aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/version
+          # aws s3 cp scripts/versions s3://cli-assets-bucket-${{ inputs.stage }}/versions
+          # aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/v4/install" "/version" "/versions"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,6 +1,6 @@
 name: 'Build and publish CLI'
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       stage:
         required: true

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -150,11 +150,5 @@ jobs:
         run: |
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }} ${{ steps.read-hashes.outputs.macos_hash }} ${{ steps.read-hashes.outputs.linux_hash }}
           cat ./scripts/install
-          # sh ./scripts/update-versions.sh ${{ inputs.full-version }} ${{ inputs.ev-domain }}
+          exit 0
 
-          # aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/${{ inputs.full-version }}/install
-          # aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/install
-          # aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/version
-          # aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/version
-          # aws s3 cp scripts/versions s3://cli-assets-bucket-${{ inputs.stage }}/versions
-          # aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/v4/install" "/version" "/versions"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -151,10 +151,3 @@ jobs:
           sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }} ${{ steps.read-hashes.outputs.macos_hash }} ${{ steps.read-hashes.outputs.linux_hash }}
           cat ./scripts/install
           sh ./scripts/update-versions.sh ${{ inputs.full-version }} ${{ inputs.ev-domain }}
-
-          # aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/${{ inputs.full-version }}/install
-          # aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/install
-          # aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/version
-          # aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/version
-          # aws s3 cp scripts/versions s3://cli-assets-bucket-${{ inputs.stage }}/versions
-          # aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/v4/install" "/version" "/versions"

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -15,13 +15,13 @@ on:
       ev-domain:
         required: true
         type: string
-    secrets:
-      aws-cloudfront-distribution-id:
-        required: true
-      aws-access-key-id:
-        required: true
-      aws-secret-access-key:
-        required: true
+    # secrets:
+    #   aws-cloudfront-distribution-id:
+    #     required: true
+    #   aws-access-key-id:
+    #     required: true
+    #   aws-secret-access-key:
+    #     required: true
 env:
   RUST_BACKTRACE: 1
   MACOS_TARGET: x86_64-apple-darwin
@@ -61,6 +61,9 @@ jobs:
           7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ./${{ env.RELEASE_DIR }}/ev-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz
         env:
           CARGO_HOME: ${{ github.workspace }}/.cargo
+      - name: Calculate Linux hash
+        run: |
+          sha256sum ${{ env.RELEASE_DIR }}/ev-${{ env.LINUX_TARGET }}-${{ inputs.full-version }}.tar.gz | cut -d ' ' -f 1 > ${{ env.RELEASE_DIR }}/linux.hash
       - name: Upload as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -96,6 +99,9 @@ jobs:
         run: |
           mv target/${{env.MACOS_TARGET}}/release/ev ${{ env.BIN_DIR }}/ev
           7z a -ttar -so -an ./${{ env.BIN_DIR }} | 7z a -si ${{ env.RELEASE_DIR }}/ev-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz
+      - name: Calculate MacOS hash
+        run: |
+          shasum -a 256 ${{ env.RELEASE_DIR }}/ev-${{ env.MACOS_TARGET }}-${{ inputs.full-version }}.tar.gz | cut -d ' ' -f 1 > ${{ env.RELEASE_DIR }}/macos.hash
       - name: Upload as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -105,12 +111,12 @@ jobs:
     needs: [compile-ubuntu, compile-macos]
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.aws-access-key-id }}
-          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
-          aws-region: us-east-1
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@v4
+      #   with:
+      #     aws-access-key-id: ${{ secrets.aws-access-key-id }}
+      #     aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+      #     aws-region: us-east-1
       - name: Download MacOS Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
@@ -121,28 +127,34 @@ jobs:
         with:
           name: linux
           path: linux
-      - name: Upload MacOS CLI to S3
-        run:
-          aws s3 cp ./macos/ev-${{ env.MACOS_TARGET }}-${{ inputs.full-version
-          }}.tar.gz s3://cli-assets-bucket-${{ inputs.stage }}/${{
-          inputs.major-version }}/${{ inputs.full-version }}/${{
-          env.MACOS_TARGET }}/ev.tar.gz
-      - name: Upload Ubuntu CLI to S3
-        run:
-          aws s3 cp ./linux/ev-${{ env.LINUX_TARGET }}-${{ inputs.full-version
-          }}.tar.gz s3://cli-assets-bucket-${{ inputs.stage }}/${{
-          inputs.major-version }}/${{ inputs.full-version }}/${{
-          env.LINUX_TARGET }}/ev.tar.gz
+      - name: Read hashes
+        id: read-hashes
+        run: |
+          echo "macos_hash=$(cat macos/macos.hash)" >> $GITHUB_OUTPUT
+          echo "linux_hash=$(cat linux/linux.hash)" >> $GITHUB_OUTPUT
+      # - name: Upload MacOS CLI to S3
+      #   run:
+      #     aws s3 cp ./macos/ev-${{ env.MACOS_TARGET }}-${{ inputs.full-version
+      #     }}.tar.gz s3://cli-assets-bucket-${{ inputs.stage }}/${{
+      #     inputs.major-version }}/${{ inputs.full-version }}/${{
+      #     env.MACOS_TARGET }}/ev.tar.gz
+      # - name: Upload Ubuntu CLI to S3
+      #   run:
+      #     aws s3 cp ./linux/ev-${{ env.LINUX_TARGET }}-${{ inputs.full-version
+      #     }}.tar.gz s3://cli-assets-bucket-${{ inputs.stage }}/${{
+      #     inputs.major-version }}/${{ inputs.full-version }}/${{
+      #     env.LINUX_TARGET }}/ev.tar.gz
       - uses: actions/checkout@v4
       - name: Update install script in S3
         working-directory: crates/ev-cli
         run: |
-          sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }}
+          sh ./scripts/generate-installer.sh ${{ inputs.full-version }} ${{ inputs.major-version }} ${{ inputs.ev-domain }} ${{ steps.read-hashes.outputs.macos_hash }} ${{ steps.read-hashes.outputs.linux_hash }}
+          cat ./scripts/install
           sh ./scripts/update-versions.sh ${{ inputs.full-version }} ${{ inputs.ev-domain }}
 
-          aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/${{ inputs.full-version }}/install
-          aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/install
-          aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/version
-          aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/version
-          aws s3 cp scripts/versions s3://cli-assets-bucket-${{ inputs.stage }}/versions
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/v4/install" "/version" "/versions"
+          # aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/${{ inputs.full-version }}/install
+          # aws s3 cp scripts/install s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/install
+          # aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/v${{ inputs.major-version }}/version
+          # aws s3 cp scripts/version s3://cli-assets-bucket-${{ inputs.stage }}/version
+          # aws s3 cp scripts/versions s3://cli-assets-bucket-${{ inputs.stage }}/versions
+          # aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/v4/install" "/version" "/versions"

--- a/crates/ev-cli/scripts/generate-installer.sh
+++ b/crates/ev-cli/scripts/generate-installer.sh
@@ -3,9 +3,15 @@
 pattern="s/{{version}}/$1/"
 major_pattern="s/{{major}}/$2/"
 domain_pattern="s/{{domain}}/$3/"
+macos_hash_pattern="s/{{macos_hash}}/$4/"
+linux_hash_pattern="s/{{linux_hash}}/$5/"
 
 sed -e "$pattern" ./scripts/install.template > ./scripts/install-temp
 sed -e "$domain_pattern" ./scripts/install-temp > ./scripts/install-temp-domain
-sed -e "$major_pattern" ./scripts/install-temp-domain > ./scripts/install
+sed -e "$major_pattern" ./scripts/install-temp-domain > ./scripts/install-temp-major
+sed -e "$macos_hash_pattern" ./scripts/install-temp-major > ./scripts/install-temp-macos
+sed -e "$linux_hash_pattern" ./scripts/install-temp-macos > ./scripts/install
 
 sed -e "$pattern" ./scripts/version.template > ./scripts/version
+
+rm ./scripts/install-temp ./scripts/install-temp-domain ./scripts/install-temp-major ./scripts/install-temp-macos

--- a/crates/ev-cli/scripts/install.template
+++ b/crates/ev-cli/scripts/install.template
@@ -4,6 +4,9 @@ set -eu
 EV_DOWNLOAD_Darwin_universal="https://cli.{{domain}}/{{major}}/{{version}}/x86_64-apple-darwin/ev.tar.gz"
 EV_DOWNLOAD_Linux_x86_64="https://cli.{{domain}}/{{major}}/{{version}}/x86_64-unknown-linux-musl/ev.tar.gz"
 
+EV_HASH_Darwin_universal="{{macos_hash}}"
+EV_HASH_Linux_x86_64="{{linux_hash}}"
+
 VERSION="{{version}}"
 PLATFORM=`uname -s`
 ARCH=`uname -m`
@@ -31,6 +34,7 @@ if [ -z ${INSTALL_PATH+x} ]; then
   INSTALL_PATH="${INSTALL_DIR}/ev"
 fi
 DOWNLOAD_URL_LOOKUP="EV_DOWNLOAD_${PLATFORM}_${ARCH}"
+HASH_LOOKUP="EV_HASH_${PLATFORM}_${ARCH}"
 
 ensure_supported_platform() {
   local x
@@ -64,6 +68,7 @@ if [ "$is_supported" = false ]; then
 fi
 
 eval DOWNLOAD_URL=\$$DOWNLOAD_URL_LOOKUP
+eval EXPECTED_HASH=\$$HASH_LOOKUP
 
 if [ "$PERFORM_INSTALL" = true ]; then
   TEMP_FILE=`mktemp "${TMPDIR:-/tmp}/ev.XXXXXXXX"`
@@ -86,6 +91,22 @@ install_via_curl() {
   curl -SL --progress-bar "$DOWNLOAD_URL" > "$TEMP_FILE"
 }
 
+verify_hash() {
+  if [ "$PLATFORM" = "Darwin" ]; then
+    COMPUTED_HASH=$(shasum -a 256 "$TEMP_FILE" | cut -d ' ' -f 1)
+  else
+    COMPUTED_HASH=$(sha256sum "$TEMP_FILE" | cut -d ' ' -f 1)
+  fi
+  
+  if [ "$COMPUTED_HASH" != "$EXPECTED_HASH" ]; then
+    echo "Error: Hash verification failed"
+    echo "Expected: $EXPECTED_HASH"
+    echo "Got:      $COMPUTED_HASH"
+    exit 4
+  fi
+  echo "Hash verification successful"
+}
+
 if [ "$PERFORM_INSTALL" = true ]; then
   if hash curl 2> /dev/null; then
     install_via_curl
@@ -95,6 +116,8 @@ if [ "$PERFORM_INSTALL" = true ]; then
     echo "You do not have curl or wget installed, which are required for this script."
     exit 3
   fi
+  
+  verify_hash
   chmod 0755 "$TEMP_FILE"
 fi
 


### PR DESCRIPTION
# Why
Allows customers to check integrity of CLI before install.

# How
- at build time: create hashes of the linux and mac binaries and inject those hashes into the install script. Then create a hash of the install script (which now contains the embedded hashes of both binaries), and output this hash in the Github actions summary - see [here](https://github.com/conor-deegan/evervault-cli/actions/runs/15633770669/attempts/1#summary-44044034822) for an example.
- at install time: the install script now computes the hash of the binary that is about to be downloaded and compares it against the embedded hash, if they differ, exit with an error. This means that if the binary has been changed since the Github action run, it would be detected in the install script which would exit with an error before completing the install.
- This way, all we, the customer, need to do is hash the install script and ensure it matches the hash in your Github action run output (which could also be added to the release notes for a new version etc.)