### PR TITLE
ci: run crate tests with cargo-nextest and Rust jobs on ev-runner-x-large

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,19 @@
+# cargo-nextest configuration
+# https://nexte.st/docs/configuration/
+#
+# A handful of enclave-build tests are annotated with `#[serial_test::serial]`
+# because they share process-wide state (they write `cert.pem`/`key.pem` into,
+# and build from, the crate's working directory). `serial_test` enforces this
+# with an in-process mutex, which works under `cargo test` because all tests run
+# in a single process.
+#
+# nextest runs each test in its own process, so that in-process mutex no longer
+# serializes anything. The `serial` test group below restores the guarantee by
+# allowing at most one of these tests to run at a time across the whole run,
+# mirroring the previous `cargo test` behaviour.
+[test-groups]
+serial = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(test_choose_output_dir) | test(test_reproducible_enclave_builds_with_pinned_version)'
+test-group = 'serial'

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -30,7 +30,7 @@ permissions:
   contents: read
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ev-runner-x-large
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint-and-test-cli.yml
+++ b/.github/workflows/lint-and-test-cli.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - name: Compile project
         run: cargo build
       - name: Prepare pcr-sign package for integration testing
@@ -21,7 +23,7 @@ jobs:
           cd crates/pcr-sign
           sh ./scripts/generate-test-signature.sh
       - name: Test project
-        run: cargo test -p ev-cli -p ev-enclave
+        run: cargo nextest run -p ev-cli -p ev-enclave
       - name: Format project
         run: cargo fmt --check
       - name: Lint project

--- a/.github/workflows/lint-and-test-cli.yml
+++ b/.github/workflows/lint-and-test-cli.yml
@@ -4,7 +4,7 @@ name: Lint and Test crates
 
 jobs:
   clippy_check_cli:
-    runs-on: ubuntu-latest
+    runs-on: ev-runner-x-large
     steps:
       - uses: actions/checkout@v5
       - uses: actions-hub/docker/cli@f5fdbfc3f9d2a9265ead8962c1314108a7b7ec5d

--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   clippy_check_cli:
-    runs-on: ubuntu-latest
+    runs-on: ev-runner-x-large
     steps:
       - uses: actions/checkout@v5
       - uses: actions-hub/docker/cli@f5fdbfc3f9d2a9265ead8962c1314108a7b7ec5d

--- a/.github/workflows/release-cli-version-staging.yml
+++ b/.github/workflows/release-cli-version-staging.yml
@@ -17,10 +17,12 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
       - name: Compile project
         run: cargo build
       - name: Test project
-        run: cargo test -p ev-cli -p ev-enclave
+        run: cargo nextest run -p ev-cli -p ev-enclave
       - name: Format project
         run: cargo fmt --check
       - name: Lint project


### PR DESCRIPTION
# Why
Two CI changes for the crate workflows:
1. Migrate the test step of the `clippy_check_cli` jobs from `cargo test` to [`cargo-nextest`](https://nexte.st/) — a next-generation test runner with per-test process isolation, better output, and faster runs.
2. Move every job that invokes the Rust compiler off `ubuntu-latest` onto the self-hosted `ev-runner-x-large` runner.

# How

### nextest migration
- Install nextest via `taiki-e/install-action@nextest` and swap `cargo test -p ev-cli -p ev-enclave` → `cargo nextest run -p ev-cli -p ev-enclave` in both jobs that run the suite:
  - `.github/workflows/lint-and-test-cli.yml`
  - `.github/workflows/release-cli-version-staging.yml`
- Add `.config/nextest.toml` with a `serial` test group (`max-threads = 1`). This is the one non-mechanical part: nextest runs each test in its own **process**, so the two enclave-build tests annotated `#[serial_test::serial]` (`test_choose_output_dir`, `test_reproducible_enclave_builds_with_pinned_version`) are no longer serialized — `serial_test`'s mutex is in-process only. Both write `cert.pem`/`key.pem` into, and build from, the crate working directory, so running them concurrently would race. The test group restores the previous one-at-a-time behaviour. Confirmed it resolves to exactly those two tests via `cargo nextest show-config test-groups`.

### Runner change
Set `runs-on: ev-runner-x-large` on the three jobs that compile Rust:

| Workflow | Job | Was | Now |
| --- | --- | --- | --- |
| `lint-and-test-cli.yml` | `clippy_check_cli` | `ubuntu-latest` | `ev-runner-x-large` |
| `release-cli-version-staging.yml` | `clippy_check_cli` | `ubuntu-latest` | `ev-runner-x-large` |
| `build-and-publish.yml` | `compile-ubuntu` | `ubuntu-latest` | `ev-runner-x-large` |

`compile-macos` was left on `macos-latest` — it builds the `x86_64-apple-darwin` target and needs a macOS host, and `ev-runner-x-large` appears to be a Linux runner. **If `ev-runner-x-large` is actually macOS-capable, say so and I'll switch it too.** Jobs that don't compile Rust (`get-version`, `upload-artifacts-to-s3`, `release-cli-version`) stay on `ubuntu-latest`.

## Verification
Ran both runners locally over the same scope:

| Runner | Result |
| --- | --- |
| `cargo test -p ev-cli -p ev-enclave` | 76 passed, same 5 failed |
| `cargo nextest run -p ev-cli -p ev-enclave` | 76 passed, same 5 failed |

The 5 failures are identical across both and purely environmental — the Docker-based enclave-build / synthetic-enclave tests, and the sandbox has no Docker daemon. They pass in CI (which provides Docker). This confirms the nextest migration is behaviour-preserving.

## Notes
- These crates contain no doctests, so `cargo nextest run` (which does not run doctests) has the same coverage as `cargo test` here.
- Both `clippy_check_cli` jobs were migrated together for consistency. The `#[serial_test::serial]` source annotations were left untouched — harmless under nextest, and still applied by local `cargo test` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RQHtsSNmrd1N7QCVRhYXCv